### PR TITLE
Refine venue detail page styling and improve focus states

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,14 +35,14 @@ export default function HomePage() {
               <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
                 <a
                   href="#hallen"
-                  className="theme-transition inline-flex items-center justify-center gap-3 rounded-full bg-[color:var(--accent-primary)] px-8 py-3 text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110"
+                  className="theme-transition inline-flex items-center justify-center gap-3 rounded-full bg-[color:var(--accent-primary)] px-8 py-3 text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
                 >
                   <span className="text-lg">⚽</span>
                   Arenen entdecken
                 </a>
                 <a
                   href="mailto:team@soccerhub.app"
-                  className="theme-transition inline-flex items-center justify-center gap-3 rounded-full border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/80 px-8 py-3 text-sm font-semibold text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/40"
+                  className="theme-transition inline-flex items-center justify-center gap-3 rounded-full border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/80 px-8 py-3 text-sm font-semibold text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
                 >
                   Beta-Deck sichern
                 </a>

--- a/components/filter-panel.tsx
+++ b/components/filter-panel.tsx
@@ -75,7 +75,7 @@ export function FilterPanel({
         </div>
         <button
           type="button"
-          className="theme-transition rounded-full px-3 py-1 text-sm font-medium text-[color:var(--accent-primary)] hover:bg-[color:var(--accent-primary)]/10 hover:text-[color:var(--accent-secondary)]"
+          className="theme-transition rounded-full px-3 py-1 text-sm font-medium text-[color:var(--accent-primary)] hover:bg-[color:var(--accent-primary)]/10 hover:text-[color:var(--accent-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
           onClick={onReset}
         >
           Zurücksetzen
@@ -94,7 +94,7 @@ export function FilterPanel({
                   type="button"
                   onClick={() => toggleSport(sport)}
                   aria-pressed={selected}
-                  className={`chip theme-transition px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] ${
+                  className={`chip theme-transition px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)] ${
                     selected ? "chip-active" : ""
                   }`}
                 >

--- a/components/filterable-venue-list.tsx
+++ b/components/filterable-venue-list.tsx
@@ -170,7 +170,7 @@ export function FilterableVenueList({ venues, sports, amenities }: FilterableVen
               <button
                 type="button"
                 onClick={() => setVisibleCount((count) => count + ITEMS_PER_PAGE)}
-                className="theme-transition inline-flex items-center gap-2 rounded-full bg-[color:var(--accent-primary)] px-8 py-3 text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110"
+                className="theme-transition inline-flex items-center gap-2 rounded-full bg-[color:var(--accent-primary)] px-8 py-3 text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
               >
                 <span aria-hidden>＋</span>
                 Mehr Arenen laden

--- a/components/venue-card.tsx
+++ b/components/venue-card.tsx
@@ -78,7 +78,7 @@ export function VenueCard({ venue }: VenueCardProps) {
         <div className="flex gap-2">
           <Link
             href={`/venues/${venue.id}`}
-            className="theme-transition flex-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/75 px-4 py-2 text-center text-sm font-semibold text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/50"
+            className="theme-transition flex-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/75 px-4 py-2 text-center text-sm font-semibold text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
           >
             Details
           </Link>
@@ -86,7 +86,7 @@ export function VenueCard({ venue }: VenueCardProps) {
             href={venue.externalUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="theme-transition flex-1 rounded-full bg-[color:var(--accent-primary)] px-4 py-2 text-center text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110"
+            className="theme-transition flex-1 rounded-full bg-[color:var(--accent-primary)] px-4 py-2 text-center text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
           >
             Jetzt buchen
           </a>

--- a/components/venue-detail.tsx
+++ b/components/venue-detail.tsx
@@ -18,46 +18,77 @@ interface VenueDetailProps {
 
 export function VenueDetail({ venue }: VenueDetailProps) {
   return (
-    <article className="container-narrow space-y-10">
-      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
-        <div className="relative h-80 overflow-hidden rounded-3xl bg-slate-200 shadow-soft">
+    <article className="container-narrow space-y-12 text-[color:var(--text-primary)]">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.6fr),minmax(0,1fr)]">
+        <div className="relative h-[320px] overflow-hidden rounded-[2.5rem] border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/50 shadow-glass">
           <Image
             src={venue.images[0]}
             alt={venue.name}
             fill
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 60vw, 800px"
-            className="object-cover"
+            className="h-full w-full object-cover"
             priority
           />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/75 via-black/20 to-transparent" aria-hidden />
+          <div className="pointer-events-none absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/15 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-white backdrop-blur" aria-hidden>
+            Arena Highlight
+          </div>
+          <div className="absolute bottom-6 left-6 right-6 flex flex-wrap items-center gap-3 rounded-2xl bg-black/35 px-5 py-3 text-sm text-white backdrop-blur">
+            <span className="inline-flex h-2 w-2 rounded-full bg-[color:var(--accent-secondary)]" aria-hidden />
+            <span className="font-semibold">{venue.city}</span>
+            <span className="text-white/60" aria-hidden>
+              •
+            </span>
+            <span className="text-white/80">{venue.address}</span>
+          </div>
         </div>
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-2">
           {venue.images.slice(1).map((image, index) => (
-            <div key={image} className="relative h-36 overflow-hidden rounded-2xl bg-slate-200">
+            <div
+              key={image}
+              className="relative h-32 overflow-hidden rounded-2xl border border-[color:var(--border-subtle)]/60 bg-[color:var(--surface-card)]/60 shadow-inner"
+            >
               <Image
                 src={image}
-                alt={`${venue.name} impression ${index + 1}`}
+                alt={`${venue.name} Impression ${index + 1}`}
                 fill
-                sizes="(max-width: 768px) 50vw, 320px"
-                className="object-cover"
+                sizes="(max-width: 768px) 33vw, (max-width: 1200px) 25vw, 240px"
+                className="h-full w-full object-cover"
               />
             </div>
           ))}
         </div>
       </div>
 
-      <header className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-8 shadow-soft md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-slate-900">{venue.name}</h1>
-          <p className="text-slate-500">{venue.address}</p>
-        </div>
-        <div className="flex flex-col items-start gap-3 text-sm text-slate-600 md:items-end">
-          <div className="text-right">
-            <p className="text-xs uppercase tracking-wider text-slate-400">Preis pro Stunde</p>
-            <p className="text-2xl font-semibold text-primary">{venue.pricePerHour.toFixed(0)} €</p>
+      <header className="glass-panel theme-transition flex flex-col gap-6 rounded-[2.75rem] border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/90 p-8 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-3">
+          <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/80 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-[color:var(--accent-primary)]">
+            Venue Profil
           </div>
-          <div className="flex flex-wrap gap-2">
+          <h1 className="text-3xl font-semibold leading-tight text-[color:var(--text-primary)]">{venue.name}</h1>
+          <p className="flex items-center gap-2 text-sm text-[color:var(--text-secondary)]">
+            <span aria-hidden>📍</span>
+            {venue.address}
+          </p>
+        </div>
+        <div className="flex flex-col items-start gap-4 text-sm text-[color:var(--text-secondary)] sm:items-end">
+          <div className="w-full rounded-2xl border border-[color:var(--border-subtle)]/70 bg-[color:var(--background-primary)]/80 px-5 py-3 text-right shadow-inner sm:w-auto">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--text-secondary)]/80">
+              Preis pro Stunde
+            </span>
+            <p className="mt-2 text-3xl font-semibold text-[color:var(--accent-primary)]">
+              {venue.pricePerHour.toFixed(0)} €
+              <span className="ml-2 text-xs font-medium uppercase tracking-[0.28em] text-[color:var(--text-secondary)]">
+                pro Std.
+              </span>
+            </p>
+          </div>
+          <div className="flex flex-wrap justify-end gap-2">
             {venue.sports.map((sport) => (
-              <span key={sport} className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+              <span
+                key={sport}
+                className="chip theme-transition px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em]"
+              >
                 {sport}
               </span>
             ))}
@@ -66,54 +97,69 @@ export function VenueDetail({ venue }: VenueDetailProps) {
             href={venue.externalUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            className="theme-transition inline-flex items-center gap-2 rounded-full bg-[color:var(--accent-primary)] px-6 py-2 text-sm font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
           >
-            Jetzt auf externer Seite buchen
+            Direkt beim Betreiber buchen
           </a>
         </div>
       </header>
 
-      <section className="grid gap-8 lg:grid-cols-[2fr,1fr]">
-        <div className="space-y-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-soft">
-          <h2 className="text-2xl font-semibold text-slate-900">Über die Halle</h2>
-          <p className="text-base leading-relaxed text-slate-600">{venue.description}</p>
-          <div className="space-y-2 text-sm text-slate-600">
-            <p className="font-semibold text-slate-800">Ausstattung</p>
-            <ul className="grid gap-2 sm:grid-cols-2">
+      <section className="grid gap-10 lg:grid-cols-[minmax(0,1.6fr),minmax(0,1fr)]">
+        <div className="space-y-8 rounded-[2.75rem] border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/85 p-8 shadow-glass">
+          <div className="space-y-3">
+            <h2 className="text-2xl font-semibold text-[color:var(--text-primary)]">Über die Halle</h2>
+            <p className="text-base leading-relaxed text-[color:var(--text-secondary)]">{venue.description}</p>
+          </div>
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--text-secondary)]/80">Ausstattung</p>
+            <ul className="grid gap-3 sm:grid-cols-2">
               {venue.amenities.map((amenity) => (
-                <li key={amenity} className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-primary" aria-hidden />
+                <li
+                  key={amenity}
+                  className="flex items-center gap-3 rounded-2xl border border-[color:var(--border-subtle)]/60 bg-[color:var(--background-primary)]/70 px-4 py-3 text-sm text-[color:var(--text-secondary)]"
+                >
+                  <span className="h-2 w-2 rounded-full bg-[color:var(--accent-secondary)]" aria-hidden />
                   {amenity}
                 </li>
               ))}
             </ul>
           </div>
         </div>
-        <aside className="space-y-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-soft">
-          <div>
-            <h2 className="text-xl font-semibold text-slate-900">Öffnungszeiten</h2>
-            <table className="mt-4 w-full border-separate border-spacing-y-2 text-sm text-slate-600">
-              <tbody>
-                {(Object.keys(weekdayLabels) as Weekday[]).map((day) => {
-                  const hours = venue.openingHours[day];
-                  return (
-                    <tr key={day}>
-                      <td className="font-medium text-slate-700">{weekdayLabels[day]}</td>
-                      <td className="text-right">
-                        {hours ? `${hours.open} - ${hours.close}` : "geschlossen"}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+        <aside className="space-y-6 rounded-[2.75rem] border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/85 p-8 shadow-glass">
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-[color:var(--text-primary)]">Öffnungszeiten</h2>
+            <dl className="space-y-2" aria-label="Öffnungszeiten nach Wochentagen">
+              {(Object.keys(weekdayLabels) as Weekday[]).map((day) => {
+                const hours = venue.openingHours[day];
+                return (
+                  <div
+                    key={day}
+                    className="flex items-center justify-between rounded-2xl border border-[color:var(--border-subtle)]/60 bg-[color:var(--background-primary)]/70 px-4 py-3"
+                  >
+                    <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--text-secondary)]">
+                      {weekdayLabels[day]}
+                    </dt>
+                    <dd className="text-sm font-medium text-[color:var(--text-primary)]">
+                      {hours ? (
+                        <span>{hours.open} – {hours.close}</span>
+                      ) : (
+                        <span className="text-[color:var(--text-secondary)]/70">geschlossen</span>
+                      )}
+                    </dd>
+                  </div>
+                );
+              })}
+            </dl>
           </div>
-          <div className="space-y-3 rounded-2xl bg-slate-100 p-4 text-sm text-slate-600">
-            <p className="font-semibold text-slate-800">Nächste Schritte</p>
+          <div className="space-y-3 rounded-2xl border border-dashed border-[color:var(--border-subtle)]/70 bg-[color:var(--background-primary)]/60 px-5 py-4 text-sm text-[color:var(--text-secondary)]">
+            <p className="text-sm font-semibold text-[color:var(--text-primary)]">Nächste Schritte</p>
             <p>
               Für Live-Verfügbarkeiten oder Reservierungen wird die Halle direkt auf ihrer Website gepflegt. Eine API-Anbindung ist im nächsten Release-Plan vorgesehen.
             </p>
-            <Link href="mailto:partners@soccerhub.app" className="font-medium text-primary">
+            <Link
+              href="mailto:partners@soccerhub.app"
+              className="theme-transition inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--accent-primary)] hover:text-[color:var(--accent-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
+            >
               Betreiber:in? SoccerHUB Partner werden
             </Link>
           </div>


### PR DESCRIPTION
## Summary
- restyle the venue detail view with glassmorphism surfaces, themed typography, and reorganised amenities and opening hours for better contrast
- add consistent focus-visible outlines to hero calls-to-action, filter chips, load-more buttons, and card actions to improve keyboard accessibility
- update venue gallery cards with gradients and borders so imagery stays legible on light and dark backgrounds

## Testing
- npm run lint *(fails: repository is missing eslint-plugin-react-hooks and eslint-plugin-react-refresh)*

------
https://chatgpt.com/codex/tasks/task_e_68db836236248332ac91de31635de18e