### PR TITLE
Refine venue card styling for consistent light/dark contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,11 @@
   --background-primary: #f3f8f3;
   --background-elevated: rgba(255, 255, 255, 0.78);
   --surface-card: rgba(255, 255, 255, 0.88);
+  --surface-card-strong: rgba(255, 255, 255, 0.94);
+  --surface-card-muted: rgba(244, 250, 246, 0.9);
+  --surface-overlay: rgba(255, 255, 255, 0.76);
+  --surface-contrast: rgba(6, 21, 13, 0.78);
+  --surface-glass-border: rgba(0, 107, 53, 0.26);
   --accent-primary: #00b861;
   --accent-secondary: #5cff9d;
   --text-primary: #06150d;
@@ -25,6 +30,11 @@
   --background-primary: #050b09;
   --background-elevated: rgba(10, 20, 18, 0.78);
   --surface-card: rgba(18, 30, 27, 0.72);
+  --surface-card-strong: rgba(14, 28, 23, 0.82);
+  --surface-card-muted: rgba(9, 20, 16, 0.76);
+  --surface-overlay: rgba(10, 24, 19, 0.74);
+  --surface-contrast: rgba(236, 255, 241, 0.12);
+  --surface-glass-border: rgba(50, 255, 136, 0.26);
   --accent-primary: #32ff88;
   --accent-secondary: #8affc4;
   --text-primary: #ecfff1;

--- a/components/venue-card.tsx
+++ b/components/venue-card.tsx
@@ -24,7 +24,7 @@ export function VenueCard({ venue }: VenueCardProps) {
       : null;
 
   return (
-    <article className="theme-transition group relative flex flex-col overflow-hidden rounded-3xl border border-[color:var(--border-subtle)]/60 bg-[color:var(--background-primary)]/95 shadow-[0_24px_80px_-40px_rgba(15,46,28,0.45)] backdrop-blur transition hover:-translate-y-1 hover:border-[color:var(--accent-primary)]/70 hover:shadow-[0_32px_120px_-48px_rgba(22,82,52,0.55)]">
+    <article className="theme-transition group relative flex flex-col overflow-hidden rounded-3xl border border-[color:var(--surface-glass-border)]/70 bg-gradient-to-br from-[color:var(--background-elevated)]/98 via-[color:var(--surface-card)] to-[color:var(--surface-card-muted)] shadow-[var(--shadow-soft)] backdrop-blur-xl transition hover:-translate-y-1 hover:border-[color:var(--accent-primary)]/60 hover:shadow-[0_32px_120px_-48px_rgba(22,82,52,0.55)]">
       <div className="relative h-56 w-full overflow-hidden">
         <Image
           src={heroImage}
@@ -34,18 +34,18 @@ export function VenueCard({ venue }: VenueCardProps) {
           className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
           priority={false}
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/15 to-transparent" aria-hidden />
-        <div className="absolute left-5 top-5 inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/85 px-3 py-1 text-xs font-semibold text-[color:var(--text-primary)] shadow-sm backdrop-blur">
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" aria-hidden />
+        <div className="absolute left-5 top-5 inline-flex items-center gap-2 rounded-full border border-[color:var(--surface-glass-border)] bg-[color:var(--surface-overlay)] px-3 py-1 text-xs font-semibold text-[color:var(--text-primary)] shadow-[0_10px_30px_-20px_rgba(0,0,0,0.5)] backdrop-blur-md">
           <span className="inline-flex h-2 w-2 items-center justify-center rounded-full bg-[color:var(--accent-secondary)]" aria-hidden />
           Smart Booking
         </div>
-        <div className="absolute left-5 bottom-5 inline-flex items-center gap-2 rounded-full border border-white/35 bg-black/45 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white shadow">
+        <div className="absolute left-5 bottom-5 inline-flex items-center gap-2 rounded-full border border-[color:var(--surface-contrast)]/50 bg-[color:var(--pitch-dark)]/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--background-primary)] shadow-[0_12px_32px_-24px_rgba(0,0,0,0.6)] backdrop-blur-sm">
           {venue.city}
         </div>
       </div>
       <div className="flex flex-1 flex-col gap-7 p-8 text-[color:var(--text-primary)]">
         <div className="space-y-4">
-          <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary)]/30 bg-[color:var(--accent-primary)]/12 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--accent-primary)]">
+          <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary)]/35 bg-[color:var(--accent-primary)]/18 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--accent-primary)]">
             <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--accent-primary)]" aria-hidden />
             Highlight
           </div>
@@ -69,7 +69,7 @@ export function VenueCard({ venue }: VenueCardProps) {
         </div>
 
         <dl className="mt-2 grid gap-4 text-sm text-[color:var(--text-secondary)] sm:grid-cols-2">
-          <div className="relative overflow-hidden rounded-2xl border border-[color:var(--border-subtle)]/70 bg-white/85 p-5 shadow-[0_12px_40px_-32px_rgba(18,62,40,0.35)]">
+          <div className="relative overflow-hidden rounded-2xl border border-[color:var(--surface-glass-border)]/80 bg-[color:var(--surface-card-strong)]/98 p-5 shadow-[0_16px_45px_-36px_rgba(18,62,40,0.5)] backdrop-blur">
             <div className="absolute inset-x-5 top-5 h-px bg-gradient-to-r from-transparent via-[color:var(--accent-primary)]/35 to-transparent" aria-hidden />
             <dt className="mt-4 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--text-secondary)]/85">
               Preis pro Stunde
@@ -85,20 +85,20 @@ export function VenueCard({ venue }: VenueCardProps) {
                   </span>
                 </>
               ) : (
-                <span className="text-xl font-semibold text-[color:var(--text-secondary)]/70">
+                <span className="text-xl font-semibold text-[color:var(--text-secondary)]/80">
                   Preis auf Anfrage
                 </span>
               )}
             </dd>
           </div>
 
-          <div className="rounded-2xl border border-[color:var(--border-subtle)]/70 bg-white/80 p-5 shadow-[0_12px_40px_-32px_rgba(18,62,40,0.3)]">
+          <div className="rounded-2xl border border-[color:var(--accent-primary)]/25 bg-gradient-to-br from-[color:var(--accent-primary)]/12 via-[color:var(--surface-card-muted)]/96 to-[color:var(--surface-card-strong)]/98 p-5 shadow-[0_16px_45px_-36px_rgba(18,62,40,0.45)] backdrop-blur">
             <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--text-secondary)]/85">
               Verfügbarkeit
             </dt>
             <dd className="mt-3 flex items-center justify-between text-sm">
               <span className="font-medium text-[color:var(--text-primary)]/85">Freie Slots</span>
-              <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary)]/30 bg-[color:var(--accent-primary)]/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--accent-primary)]">
+              <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary)]/45 bg-gradient-to-r from-[color:var(--accent-primary)]/20 via-[color:var(--accent-primary)]/12 to-[color:var(--accent-secondary)]/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--accent-primary)]">
                 Live
               </span>
             </dd>
@@ -111,7 +111,7 @@ export function VenueCard({ venue }: VenueCardProps) {
             {venue.amenities.slice(0, 4).map((amenity) => (
               <li
                 key={amenity}
-                className="theme-transition inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)]/60 bg-white/80 px-3 py-2 shadow-[0_10px_30px_-28px_rgba(18,62,40,0.45)]"
+                className="theme-transition inline-flex items-center gap-2 rounded-xl border border-[color:var(--surface-glass-border)]/70 bg-[color:var(--surface-card-muted)]/95 px-3 py-2 shadow-[0_10px_30px_-28px_rgba(18,62,40,0.45)]"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--accent-secondary)]" aria-hidden />
                 <span className="leading-tight">{amenity}</span>
@@ -123,7 +123,7 @@ export function VenueCard({ venue }: VenueCardProps) {
         <div className="mt-auto flex gap-2">
           <Link
             href={`/venues/${venue.id}`}
-            className="theme-transition flex-1 rounded-full border border-[color:var(--border-subtle)]/60 bg-white/90 px-4 py-2 text-center text-sm font-semibold text-[color:var(--text-primary)] shadow-[0_14px_32px_-26px_rgba(18,62,40,0.45)] hover:border-[color:var(--accent-primary)]/50 hover:text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
+            className="theme-transition flex-1 rounded-full border border-[color:var(--surface-glass-border)]/80 bg-[color:var(--surface-card)]/95 px-4 py-2 text-center text-sm font-semibold text-[color:var(--text-primary)] shadow-[0_14px_32px_-26px_rgba(18,62,40,0.45)] hover:border-[color:var(--accent-primary)]/45 hover:text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
           >
             Details
           </Link>


### PR DESCRIPTION
## Summary
- add shared surface tokens so cards and pills adapt to light and dark themes
- refresh venue card badges, stats, and buttons for better contrast and parity with the latest designs

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in repo configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dba30d31a48332af1bd2b5822cf394