### PR TITLE
Rebrand app to Sportshub and expand multi-sport data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Turftime Venues – Sporthallen MVP
+# Sportshub – Multi-Sport Venue MVP
 
-Dieses Projekt ist ein Next.js 14 MVP für eine Sporthallen-Plattform. Nutzer:innen können Soccer- und Padelhallen im Raum Mannheim / Heidelberg vergleichen und gelangen per Klick zur externen Buchung der Betreiber:innen.
+Dieses Projekt ist ein Next.js-14-MVP für Sportshub – ein kuratiertes Verzeichnis für Fußballhallen, Padel-Center und Boutique-Fitnessstudios in der Metropolregion Rhein-Neckar. Nutzer:innen vergleichen Flächen, filtern nach Ausstattung und springen direkt zur externen Buchung der Betreiber:innen.
 
 ## Quickstart
 
@@ -13,12 +13,12 @@ npm run dev
 
 ## Features
 
-- 📍 Listenansicht mit Filtern für Sportart, Ort, Preis, Öffnungszeiten und Ausstattung
+- 📍 Listenansicht mit Filtern für Sportart (Fußball, Padel, Fitness), Ort, Preis, Öffnungszeiten und Ausstattung
 - 🗂️ Sortierung nach Preis oder Name inkl. lazy geladenem „Mehr anzeigen“-Button
 - 🖼️ Detailseite mit Galerie, Öffnungszeiten-Tabelle und CTA zur externen Buchung
 - ⚡ App Router, Server Components und Client-Filter (Next.js 14 + TypeScript)
 - 🎨 Tailwind CSS mit mobile-first Layout und modernen Karten
-- 📁 Mock-Daten aus `data/venues.json` (5 Beispielhallen)
+- 📁 Mock-Daten aus `data/venues.json` (kuratiertes Multi-Sport-Line-up)
 
 ## Struktur
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,24 +10,24 @@ const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
   title: {
-    default: "SoccerHUB | Indoor Soccer & Padel Arenen",
-    template: "%s | SoccerHUB",
+    default: "Sportshub | Fußball, Padel & Boutique-Fitness",
+    template: "%s | Sportshub",
   },
   description:
-    "SoccerHUB ist dein digitales Clubhaus für Premium Soccer- und Padelhallen. Vergleiche Arenen, Filtere nach Preisen und Ausstattung und buche direkt beim Betreiber.",
+    "Sportshub ist dein kuratiertes Digital-Clubhaus für Premium-Fußballhallen, Padel-Courts und Boutique-Fitnessstudios in Rhein-Neckar. Vergleiche Preise, Ausstattung und freie Slots und buche direkt beim Betreiber.",
   keywords: [
-    "SoccerHUB",
+    "Sportshub",
     "Fußballhalle",
-    "Soccer",
     "Padel",
-    "Indoor Fußball",
+    "Fitnessstudio",
+    "Indoor Sport",
     "Buchung",
   ],
-  metadataBase: new URL("https://soccerhub.app"),
+  metadataBase: new URL("https://sportshub.app"),
   openGraph: {
-    title: "SoccerHUB",
+    title: "Sportshub",
     description:
-      "SoccerHUB bündelt Soccer- und Padelhallen in einer modernen Übersicht – Preise, Ausstattung & Kontakt auf einen Blick.",
+      "Sportshub bündelt Fußballhallen, Padel-Courts und Boutique-Fitnessstudios – Preise, Ausstattung & Kontakt auf einen Blick.",
     type: "website",
   },
 };
@@ -49,14 +49,14 @@ export default function RootLayout({
           >
             <div className="container-narrow grid gap-6 text-sm text-[color:var(--text-secondary)] sm:grid-cols-[minmax(0,1fr),auto] sm:items-center">
               <div className="space-y-2">
-                <p className="text-base font-semibold text-[color:var(--text-primary)]">Bleib mit SoccerHUB verbunden</p>
+                <p className="text-base font-semibold text-[color:var(--text-primary)]">Bleib mit Sportshub verbunden</p>
                 <p>
-                  &copy; {new Date().getFullYear()} SoccerHUB. Crafted für ambitionierte Teams und Betreiber:innen von Henrik und Sharky.
+                  &copy; {new Date().getFullYear()} Sportshub. Crafted für ambitionierte Teams und Betreiber:innen von Henrik und Sharky.
                 </p>
               </div>
               <div className="flex flex-wrap items-center gap-3">
-                <a className="chip px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em]" href="mailto:team@soccerhub.app">
-                  team@soccerhub.app
+                <a className="chip px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em]" href="mailto:team@sportshub.app">
+                  team@sportshub.app
                 </a>
                 <a className="chip px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em]" href="https://www.linkedin.com">
                   LinkedIn

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,10 +28,10 @@ export default function HomePage() {
               </div>
               <div className="space-y-7">
                 <h1 className="text-4xl font-semibold leading-tight text-[color:var(--text-primary)] sm:text-5xl">
-                  SoccerHUB – Liquid Glass Playbook für Indoor-Soccer &amp; Padel
+                  Sportshub – Liquid Playbook für Fußball, Padel &amp; Boutique-Fitness
                 </h1>
                 <p className="max-w-2xl text-lg text-[color:var(--text-secondary)]">
-                  Stell dir ein Taktikboard in Apple-Ästhetik vor: sanfte Reflexionen, Glassmorphism und Fokus auf dein Team. Wir veredeln jede Buchung mit Fußball-DNA – von Spielzügen bis Slot-Radar.
+                  Stell dir ein Taktikboard in Apple-Ästhetik vor: sanfte Reflexionen, Glassmorphism und Fokus auf Performance. Wir kuratieren Premium-Courts, Studio-Lofts und Recovery-Zonen – inklusive Preisfenstern, Ausstattung und Live-Verfügbarkeiten.
                 </p>
               </div>
               <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
@@ -43,14 +43,18 @@ export default function HomePage() {
                   Arenen entdecken
                 </a>
                 <a
-                  href="mailto:team@soccerhub.app"
+                  href="mailto:team@sportshub.app"
                   className="theme-transition inline-flex items-center justify-center gap-3 rounded-full border border-[color:var(--surface-glass-border)] bg-[color:var(--surface-card)] px-8 py-3 text-sm font-semibold text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/40 hover:bg-[color:var(--surface-card-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
                 >
                   Beta-Deck sichern
                 </a>
               </div>
               <div className="grid gap-4 sm:grid-cols-3">
-                {[{ label: "360° Arena Profile", description: "Fotos, Slots &amp; Preise in Ultra-Clear." }, { label: "Live Slot Radar", description: "aktualisiert im 5-Minuten-Takt" }, { label: "Direkte Buchung", description: "ohne Anruf, ohne Wartezeit" }].map((feature) => (
+                {[
+                  { label: "360° Venue Profiles", description: "Fotos, Slots &amp; Deals glasklar." },
+                  { label: "Hybrid Sports", description: "Fußball, Padel &amp; Functional Training" },
+                  { label: "Direct Booking", description: "ohne Anruf, ohne Wartezeit" },
+                ].map((feature) => (
                   <div
                     key={feature.label}
                     className="theme-transition rounded-2xl border border-[color:var(--surface-glass-border)] bg-[color:var(--surface-card-muted)] p-4 text-left text-sm text-[color:var(--text-secondary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur"
@@ -89,7 +93,7 @@ export default function HomePage() {
                       <span className="text-4xl font-black text-[color:var(--accent-secondary)] drop-shadow-[0_0_15px_rgba(92,255,157,0.4)]">19:30</span>
                     </div>
                     <div className="grid gap-3 text-[11px] uppercase tracking-[0.3em] text-white/70 sm:grid-cols-3">
-                      {["Padel Courts · 4", "Soccer XL · Slots frei", "Teams · 78"].map((item) => (
+                      {["Padel Courts · 4", "Indoor Soccer XL · Slots frei", "Functional Gym · 2 Studios"].map((item) => (
                         <div
                           key={item}
                           className="rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-center font-semibold shadow-[0_0_20px_-12px_rgba(255,255,255,0.8)]"
@@ -103,7 +107,7 @@ export default function HomePage() {
                     {[
                       { label: "Integrationen", value: "12 Systeme" },
                       { label: "Verfügbarkeiten", value: "Live Refresh" },
-                      { label: "Team Ranking", value: "Beta Zugriff" },
+                      { label: "Mitglieder", value: "Teams &amp; Studios" },
                     ].map((info) => (
                     <div
                       key={info.label}
@@ -132,13 +136,17 @@ export default function HomePage() {
           <div className="relative grid gap-12 lg:grid-cols-[minmax(0,1fr),320px]">
             <div className="space-y-10">
               <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr),minmax(0,320px)] sm:items-center">
-                <h2 className="text-3xl font-semibold text-[color:var(--text-primary)]">Match Center Insights</h2>
+                <h2 className="text-3xl font-semibold text-[color:var(--text-primary)]">Match &amp; Training Insights</h2>
                 <p className="text-base text-[color:var(--text-secondary)]">
-                  Liquid Lines, klare Typo und Spielfeld-Flair: Unser Dashboard zeigt Filter, Preisfenster und Buchungswege wie ein aufpoliertes Coaching-Tablet – inklusive Echtzeit-Intelligenz.
+                  Liquid Lines, klare Typo und Spielfeld-Flair: Unser Dashboard zeigt Filter, Preisfenster und Buchungswege wie ein aufpoliertes Coaching-Tablet – inklusive Echtzeit-Intelligenz für Court, Gym &amp; Recovery.
                 </p>
               </div>
               <dl className="grid gap-6 md:grid-cols-3">
-                {[{ title: "Teams on Board", value: "180+", detail: "Beta-Teams testen Live-Buchungen &amp; Slot-Radar." }, { title: "Operator Sync", value: "12 Integrationen", detail: "Von lokalen Betreiber:innen bis Pro Clubs." }, { title: "Instant Visibility", value: "< 45 Sek.", detail: "Von Anfrage bis Buchung ohne Medienbrüche." }].map((stat) => (
+                {[
+                  { title: "Teams on Board", value: "180+", detail: "Beta-Teams &amp; Studios testen Live-Buchungen." },
+                  { title: "Operator Sync", value: "12 Integrationen", detail: "Von lokalen Betreiber:innen bis Pro Clubs." },
+                  { title: "Instant Visibility", value: "< 45 Sek.", detail: "Von Anfrage bis Buchung ohne Medienbrüche." },
+                ].map((stat) => (
                   <div key={stat.title} className="relative overflow-hidden rounded-2xl border border-[color:var(--surface-glass-border)] bg-[color:var(--surface-card-muted)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur">
                     <div className="pointer-events-none absolute -left-10 top-1/2 h-24 w-24 -translate-y-1/2 rounded-full bg-[radial-gradient(circle,rgba(92,255,157,0.18),transparent_70%)] blur-xl" aria-hidden />
                     <dt className="relative text-xs uppercase tracking-[0.3em] text-[color:var(--text-secondary)]">{stat.title}</dt>
@@ -151,8 +159,11 @@ export default function HomePage() {
             <div className="space-y-6 rounded-3xl border border-[color:var(--surface-glass-border)] bg-[color:var(--surface-card-muted)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur">
               <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--text-secondary)]">So klappt die Buchung</p>
               <ol className="space-y-5 text-sm text-[color:var(--text-secondary)]">
-                {["Wähle Sportart, Preisfenster &amp; Ausstattung.", "Prüfe freie Slots im Echtzeit-Radar und sichere dir deinen Termin.", "Informiere dein Team via Deep Link und nutze optionale Add-ons."]
-                  .map((step, index) => (
+                {[
+                  "Wähle Sportart – Fußballhalle, Padel-Court oder Fitnessstudio.",
+                  "Prüfe freie Slots im Echtzeit-Radar und sichere dir deinen Termin.",
+                  "Informiere Team &amp; Coaches via Deep Link und füge Add-ons hinzu.",
+                ].map((step, index) => (
                   <li key={step} className="flex gap-4">
                     <span className="mt-0.5 inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-[color:var(--accent-primary)]/20 text-xs font-semibold text-[color:var(--accent-primary)]">
                       {index + 1}

--- a/components/filter-panel.tsx
+++ b/components/filter-panel.tsx
@@ -68,9 +68,9 @@ export function FilterPanel({
       <header className="flex items-center justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--text-secondary)]">Filter</p>
-          <h2 className="text-xl font-semibold text-[color:var(--text-primary)]">Finde deine Halle</h2>
+          <h2 className="text-xl font-semibold text-[color:var(--text-primary)]">Finde deinen Spot</h2>
           <p className="mt-1 text-xs text-[color:var(--text-secondary)]/80">
-            Justiere Sportarten, Preislevel und Ausstattung für deinen perfekten Slot.
+            Justiere Sportarten, Preislevel und Ausstattung für deinen perfekten Slot – ob Matchday, Padel-Session oder Functional Training.
           </p>
         </div>
         <button

--- a/components/filterable-venue-list.tsx
+++ b/components/filterable-venue-list.tsx
@@ -151,9 +151,9 @@ export function FilterableVenueList({ venues, sports, amenities }: FilterableVen
                 Live Übersicht
               </div>
               <div>
-                <h2 className="text-2xl font-semibold text-[color:var(--text-primary)]">{sortedVenues.length} Arenen im SoccerHUB</h2>
+                <h2 className="text-2xl font-semibold text-[color:var(--text-primary)]">{sortedVenues.length} Spots im Sportshub</h2>
                 <p className="text-sm text-[color:var(--text-secondary)]">
-                  Passe Filter, sortiere nach Preis oder Name und speichere Favoriten für deinen nächsten Spieltag.
+                  Passe Filter, sortiere nach Preis oder Name und speichere Favoriten für das nächste Match, Training oder Recovery-Session.
                 </p>
               </div>
             </div>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -39,9 +39,9 @@ export function SiteHeader() {
               <span className="relative font-black">SH</span>
             </span>
             <span className="flex flex-col leading-tight">
-              <span>SoccerHUB</span>
+              <span>Sportshub</span>
               <span className="text-xs font-medium uppercase tracking-[0.3em] text-[color:var(--text-secondary)]">
-                Football Intelligence
+                Football · Padel · Fitness
               </span>
             </span>
           </Link>
@@ -57,7 +57,7 @@ export function SiteHeader() {
             Kontakt
           </Link>
           <a
-            href="mailto:team@soccerhub.app"
+            href="mailto:team@sportshub.app"
             className="theme-transition inline-flex items-center gap-2 rounded-full bg-[color:var(--accent-primary)] px-5 py-2 text-[color:var(--background-primary)] shadow-glow hover:brightness-110"
           >
             Beta-Zugang
@@ -67,7 +67,7 @@ export function SiteHeader() {
           <div className="hidden items-center gap-2 rounded-full border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/70 px-4 py-2 text-[color:var(--text-secondary)] sm:flex">
             <span className="text-xs font-semibold uppercase tracking-[0.28em]">Live</span>
             <span className="inline-flex items-center gap-2 text-xs font-semibold text-[color:var(--accent-primary)]">
-              ⚽ 82 Arenen gelistet
+              🏟️ 82 Spots gelistet
             </span>
           </div>
           <button
@@ -120,7 +120,7 @@ export function SiteHeader() {
           </li>
           <li>
             <a
-              href="mailto:team@soccerhub.app"
+              href="mailto:team@sportshub.app"
               onClick={() => setIsMobileNavOpen(false)}
               className="theme-transition inline-flex w-full items-center justify-center rounded-full bg-[color:var(--accent-primary)] px-4 py-2 font-semibold text-[color:var(--background-primary)] shadow-glow hover:brightness-110"
             >

--- a/components/venue-card.tsx
+++ b/components/venue-card.tsx
@@ -7,9 +7,11 @@ interface VenueCardProps {
 }
 
 const sportLabels: Record<string, string> = {
-  Soccer: "Soccer",
+  "Fußball Indoor": "Fußball Indoor",
   Padel: "Padel",
-  Futsal: "Futsal",
+  "Functional Fitness": "Functional Fitness",
+  Fitnessstudio: "Fitnessstudio",
+  Recovery: "Recovery",
 };
 
 export function VenueCard({ venue }: VenueCardProps) {

--- a/components/venue-detail.tsx
+++ b/components/venue-detail.tsx
@@ -198,10 +198,10 @@ export function VenueDetail({ venue }: VenueDetailProps) {
               Für Live-Verfügbarkeiten oder Reservierungen wird die Halle direkt auf ihrer Website gepflegt. Eine API-Anbindung ist im nächsten Release-Plan vorgesehen.
             </p>
             <Link
-              href="mailto:partners@soccerhub.app"
+              href="mailto:partners@sportshub.app"
               className="theme-transition inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--accent-primary)] hover:text-[color:var(--accent-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
             >
-              Betreiber:in? SoccerHUB Partner werden
+              Betreiber:in? Sportshub Partner werden
             </Link>
           </div>
         </aside>

--- a/data/venues.json
+++ b/data/venues.json
@@ -1,170 +1,258 @@
 [
   {
-    "id": "rhein-neckar-fussballcenter",
-    "name": "Rhein-Neckar Fußballcenter",
+    "id": "green-dome-mannheim",
+    "name": "Green Dome Mannheim",
     "city": "Mannheim",
-    "address": "Theodor-Heuss-Anlage 17, 68165 Mannheim",
-    "description": "Sportanlage mit 5 Spielfeldern (30×15 m u.a.), Gastronomie und umfassender Ausstattung.",  
-    "pricePerHour": null,  
-    "sports": ["Soccer"],
-    "amenities": ["Duschen", "Umkleiden", "Parkplätze", "Gastronomie", "Shop", "Barrierefrei"],  
-    "openingHours": null,  
-    "images": [],
-    "externalUrl": "https://www.rhein-neckar-fussballcenter.de/Preise-und-Angebote/",
-    "notes": "Angelegt aus Eversports und Betreiberinformationen."  
+    "address": "Industriestraße 17, 68169 Mannheim",
+    "description": "Flagship-Hub mit zwei Indoor-Fußballfeldern, vier Padel-Courts und einem Boutique-Fitnessloft inklusive Recovery-Zone.",
+    "pricePerHour": 89,
+    "sports": ["Fußball Indoor", "Padel", "Functional Fitness"],
+    "amenities": [
+      "LED-Courts",
+      "Duschen",
+      "Sauna & Ice Bath",
+      "Athletik-Loft",
+      "Livetracking",
+      "Parkplätze"
+    ],
+    "openingHours": {
+      "monday": { "open": "09:00", "close": "23:00" },
+      "tuesday": { "open": "09:00", "close": "23:00" },
+      "wednesday": { "open": "09:00", "close": "23:00" },
+      "thursday": { "open": "09:00", "close": "23:00" },
+      "friday": { "open": "09:00", "close": "01:00" },
+      "saturday": { "open": "08:00", "close": "01:00" },
+      "sunday": { "open": "08:00", "close": "22:00" }
+    },
+    "images": [
+      "https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d",
+      "https://images.unsplash.com/photo-1534159460-0f47c0b9d4d0",
+      "https://images.unsplash.com/photo-1517836357463-d25dfeac3438"
+    ],
+    "externalUrl": "https://sportshub.app/green-dome",
+    "notes": "Beta-Partner mit Live-Slot-API."
   },
   {
-    "id": "calhanoglu-fussballzentrum-kaefertal",
-    "name": "Çalhanoğlu Fußballzentrum Mannheim-Käfertal",
-    "city": "Mannheim",
-    "address": null,
-    "description": "Fußballhalle mit Indoor-Kunstrasenplätzen, geöffnet ab 14 Uhr an Wochentagen, ganztägig am Wochenende.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://www.fussballzentrum-kaefertal.de/preise-1",
-    "notes": null
-  },
-  {
-    "id": "lufun-soccer-indoorspielplatz",
-    "name": "LuFUN Soccer & Indoorspielplatz",
-    "city": "Mannheim / Ludwigshafen Region",
-    "address": null,
-    "description": "Indoor-Soccer kombiniert mit Indoorspielplatz, geeignet für Familien und Events.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://lufun.de/soccer/",
-    "notes": null
-  },
-  {
-    "id": "indoor-soccerpark-eventhouse-weber",
-    "name": "Indoor Soccerpark (Eventhouse Weber)",
-    "city": null,
-    "address": null,
-    "description": "Mehrere Indoor-Courts, Bühne / Event-Setting möglich.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://soccer.eventhouse-weber.de/preise/",
-    "notes": null
-  },
-  {
-    "id": "kick-mit-indoor-soccer-bischofsheim",
-    "name": "Kick Mit Indoor Soccer Bischofsheim",
-    "city": "Bischofsheim",
-    "address": "Am Schindberg 23, 65474 Bischofsheim",
-    "description": "Indoor-Soccer mit drei Courts (30×15 m), ideal für Hobbykicken und Vereinsgruppen. (Quelle: Kick Mit Website) ",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://kick-mit.info/hobby-kicken",
-    "notes": "Preise: z. B. 1,5 h = 75 € Mo–Fr 12–18, 2 h = 95 € etc. :contentReference[oaicite:0]{index=0}"
-  },
-  {
-    "id": "indoor-soccer-halle-langen",
-    "name": "Indoor Soccer Langen",
-    "city": "Langen",
-    "address": null,
-    "description": "Indoor-Soccerhalle Langen – Standardangebot laut Website.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://www.soccerhalle-langen.de/",
-    "notes": null
-  },
-  {
-    "id": "indoor-soccerhalle-manaschaff",
-    "name": "Indoor Soccerhalle Mainaschaff",
-    "city": "Mainaschaff",
-    "address": null,
-    "description": "Indoor-Soccerhalle in Mainaschaff mit Buchung via Website.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://www.soccerhalle-mainaschaff.de/preise",
-    "notes": null
-  },
-  {
-    "id": "soccArena-heidelberg",
-    "name": "SoccArena Heidelberg",
+    "id": "padel-district-heidelberg",
+    "name": "Padel District Heidelberg",
     "city": "Heidelberg",
-    "address": null,
-    "description": "Indoor-Soccer in Heidelberg, mit Verfügbarkeitsinformationen auf der Website.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://soccarena-hd.de/sportarten/indoor-soccer/",
-    "notes": null
+    "address": "Czernyring 20, 69115 Heidelberg",
+    "description": "Highend-Padelclub mit sechs Indoor-Courts, Match-Analyse und Sky-Lounge.",
+    "pricePerHour": 64,
+    "sports": ["Padel"],
+    "amenities": [
+      "Glas-Courts",
+      "Match-Tracking",
+      "Sky-Lounge",
+      "Duschen",
+      "Pro Shop",
+      "Parkplätze"
+    ],
+    "openingHours": {
+      "monday": { "open": "08:00", "close": "23:00" },
+      "tuesday": { "open": "08:00", "close": "23:00" },
+      "wednesday": { "open": "08:00", "close": "23:00" },
+      "thursday": { "open": "08:00", "close": "23:00" },
+      "friday": { "open": "08:00", "close": "00:00" },
+      "saturday": { "open": "08:00", "close": "00:00" },
+      "sunday": { "open": "09:00", "close": "22:00" }
+    },
+    "images": [
+      "https://images.unsplash.com/photo-1598970605070-57be927b8be8",
+      "https://images.unsplash.com/photo-1618836884767-5e5d5e79f59c"
+    ],
+    "externalUrl": "https://sportshub.app/padel-district"
   },
   {
-    "id": "pfalzsoccer-dudenhofen",
-    "name": "Pfalzsoccer – Soccerhalle Dudenhofen",
-    "city": "Dudenhofen",
-    "address": null,
-    "description": "Soccerhalle in Dudenhofen, Teil der Pfalzsoccer-Gruppe.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://pfalzsoccer-dudenhofen.de/",
-    "notes": null
+    "id": "pulse-athletic-club",
+    "name": "Pulse Athletic Club Heidelberg",
+    "city": "Heidelberg",
+    "address": "Bergheimer Str. 104, 69115 Heidelberg",
+    "description": "Boutique-Fitnessstudio mit Functional Floor, Personal-Coaching und Recovery Bar.",
+    "pricePerHour": 35,
+    "sports": ["Functional Fitness", "Fitnessstudio"],
+    "amenities": [
+      "Personal Coaching",
+      "Recovery Bar",
+      "Duschen",
+      "Locker Smart",
+      "Sauna",
+      "Parking Valet"
+    ],
+    "openingHours": {
+      "monday": { "open": "06:00", "close": "22:00" },
+      "tuesday": { "open": "06:00", "close": "22:00" },
+      "wednesday": { "open": "06:00", "close": "22:00" },
+      "thursday": { "open": "06:00", "close": "22:00" },
+      "friday": { "open": "06:00", "close": "21:00" },
+      "saturday": { "open": "08:00", "close": "18:00" },
+      "sunday": { "open": "09:00", "close": "16:00" }
+    },
+    "images": [
+      "https://images.unsplash.com/photo-1517836357463-d25dfeac3438",
+      "https://images.unsplash.com/photo-1554284126-aa88f22d8b74"
+    ],
+    "externalUrl": "https://sportshub.app/pulse-athletic"
   },
   {
-    "id": "europa-arena-karlsruhe-neureut",
-    "name": "EuropaArena Karlsruhe / Neureut",
-    "city": "Karlsruhe / Neureut",
-    "address": null,
-    "description": "Multifunktionsarena mit Sportbuchungen, auch Soccer möglich.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
+    "id": "stadion-loft-ludwigshafen",
+    "name": "Stadion Loft Ludwigshafen",
+    "city": "Ludwigshafen",
+    "address": "Friesenheimstraße 12, 67063 Ludwigshafen",
+    "description": "Industrial-Loft mit Indoor-Fußballfeld, Sprintbahn und Strength-Area für Teams &amp; Corporate-Events.",
+    "pricePerHour": 72,
+    "sports": ["Fußball Indoor", "Functional Fitness"],
+    "amenities": [
+      "Sprintbahn",
+      "Livestream Setup",
+      "Team-Locker",
+      "Eventküche",
+      "Duschen",
+      "Parkplätze"
+    ],
     "openingHours": null,
-    "images": [],
-    "externalUrl": "https://europa-arena.ebusy.de/",
-    "notes": null
+    "images": ["https://images.unsplash.com/photo-1582719478250-c89cae4dc85b"],
+    "externalUrl": "https://sportshub.app/stadion-loft"
   },
   {
-    "id": "soccer-palace-rastatt",
-    "name": "Soccer Palace Rastatt",
-    "city": "Rastatt",
-    "address": null,
-    "description": "Soccer-Arena in Rastatt, mit Veranstaltungscharakter.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
-    "openingHours": null,
-    "images": [],
-    "externalUrl": "https://soccer-palace.eu/",
-    "notes": null
+    "id": "rhein-neckar-padel-campus",
+    "name": "Rhein-Neckar Padel Campus",
+    "city": "Weinheim",
+    "address": "Güterbahnhofstraße 9, 69469 Weinheim",
+    "description": "Padel- und Fitnesscampus mit Outdoor-Terrasse, Athletik-Box und Café.",
+    "pricePerHour": 56,
+    "sports": ["Padel", "Functional Fitness"],
+    "amenities": [
+      "Outdoor-Terrasse",
+      "Athletik-Box",
+      "Cafe",
+      "Kinderlounge",
+      "Duschen",
+      "Parkplätze"
+    ],
+    "openingHours": {
+      "monday": { "open": "07:00", "close": "23:00" },
+      "tuesday": { "open": "07:00", "close": "23:00" },
+      "wednesday": { "open": "07:00", "close": "23:00" },
+      "thursday": { "open": "07:00", "close": "23:00" },
+      "friday": { "open": "07:00", "close": "00:00" },
+      "saturday": { "open": "08:00", "close": "00:00" },
+      "sunday": { "open": "08:00", "close": "22:00" }
+    },
+    "images": [
+      "https://images.unsplash.com/photo-1517649763962-0c623066013b",
+      "https://images.unsplash.com/photo-1516274626895-055a99214f08"
+    ],
+    "externalUrl": "https://sportshub.app/rhein-neckar-padel"
   },
   {
-    "id": "soccer-arena-sindelfingen",
-    "name": "Soccer Arena Sindelfingen",
-    "city": "Sindelfingen",
-    "address": null,
-    "description": "Indoor-Arena in Sindelfingen, Teil der EventArena Gruppe.",
-    "pricePerHour": null,
-    "sports": ["Soccer"],
-    "amenities": [],
+    "id": "urban-soccer-lab-karlsruhe",
+    "name": "Urban Soccer Lab Karlsruhe",
+    "city": "Karlsruhe",
+    "address": "Rheinstraße 88, 76185 Karlsruhe",
+    "description": "Urbaner Indoor-Soccer-Hotspot mit LED-Bande, Tracking-Kameras und Skills-Area.",
+    "pricePerHour": 75,
+    "sports": ["Fußball Indoor"],
+    "amenities": [
+      "LED-Bande",
+      "Skills-Area",
+      "Duschen",
+      "Sportsbar",
+      "Livetracking",
+      "Parkplätze"
+    ],
+    "openingHours": {
+      "monday": { "open": "10:00", "close": "23:00" },
+      "tuesday": { "open": "10:00", "close": "23:00" },
+      "wednesday": { "open": "10:00", "close": "23:00" },
+      "thursday": { "open": "10:00", "close": "23:00" },
+      "friday": { "open": "10:00", "close": "01:00" },
+      "saturday": { "open": "09:00", "close": "01:00" },
+      "sunday": { "open": "09:00", "close": "22:00" }
+    },
+    "images": ["https://images.unsplash.com/photo-1518609878373-06d740f60d8b"],
+    "externalUrl": "https://sportshub.app/urban-soccer-lab"
+  },
+  {
+    "id": "next-level-performance-club",
+    "name": "Next Level Performance Club",
+    "city": "Mannheim",
+    "address": "Neckarauer Str. 120, 68163 Mannheim",
+    "description": "Performance-Studio mit Personal-Pods, Cycling-Lab und Mobility-Classes.",
+    "pricePerHour": 38,
+    "sports": ["Fitnessstudio", "Functional Fitness"],
+    "amenities": [
+      "Personal Pods",
+      "Cycling Lab",
+      "Mobility Classes",
+      "Recovery Lounge",
+      "Duschen",
+      "Parkplätze"
+    ],
     "openingHours": null,
-    "images": [],
-    "externalUrl": "https://dieeventarena.de/",
-    "notes": null
+    "images": [
+      "https://images.unsplash.com/photo-1576678927484-cc907957088c",
+      "https://images.unsplash.com/photo-1571019614242-c5c5dee9f50b"
+    ],
+    "externalUrl": "https://sportshub.app/next-level"
+  },
+  {
+    "id": "arena-54-multisport",
+    "name": "Arena 54 Multisport",
+    "city": "Heidelberg",
+    "address": "Kurfürsten-Anlage 54, 69115 Heidelberg",
+    "description": "Multisport-Arena mit Indoor-Fußball, zwei Padel-Courts und HIIT-Studio.",
+    "pricePerHour": 82,
+    "sports": ["Fußball Indoor", "Padel", "Functional Fitness"],
+    "amenities": [
+      "HIIT Studio",
+      "Team-Locker",
+      "Café",
+      "Duschen",
+      "Livetracking",
+      "Parkplätze"
+    ],
+    "openingHours": {
+      "monday": { "open": "09:00", "close": "23:00" },
+      "tuesday": { "open": "09:00", "close": "23:00" },
+      "wednesday": { "open": "09:00", "close": "23:00" },
+      "thursday": { "open": "09:00", "close": "23:00" },
+      "friday": { "open": "09:00", "close": "00:00" },
+      "saturday": { "open": "08:00", "close": "00:00" },
+      "sunday": { "open": "08:00", "close": "22:00" }
+    },
+    "images": [
+      "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b",
+      "https://images.unsplash.com/photo-1579758629938-03607ccdbaba"
+    ],
+    "externalUrl": "https://sportshub.app/arena-54"
+  },
+  {
+    "id": "skyline-recovery-studio",
+    "name": "Skyline Recovery Studio",
+    "city": "Mannheim",
+    "address": "Turley-Platz 5, 68167 Mannheim",
+    "description": "Recovery- und Mobility-Studio mit Eisbädern, Infrared-Sauna und Athletik-Kursen.",
+    "pricePerHour": 45,
+    "sports": ["Fitnessstudio", "Recovery"],
+    "amenities": [
+      "Eisbad",
+      "Infrared-Sauna",
+      "Athletik-Kurse",
+      "Personal Coaching",
+      "Lounge",
+      "Parkplätze"
+    ],
+    "openingHours": {
+      "monday": { "open": "07:00", "close": "21:00" },
+      "tuesday": { "open": "07:00", "close": "21:00" },
+      "wednesday": { "open": "07:00", "close": "21:00" },
+      "thursday": { "open": "07:00", "close": "21:00" },
+      "friday": { "open": "07:00", "close": "20:00" },
+      "saturday": { "open": "09:00", "close": "18:00" },
+      "sunday": { "open": "10:00", "close": "16:00" }
+    },
+    "images": ["https://images.unsplash.com/photo-1546484959-fc3140896cf3"],
+    "externalUrl": "https://sportshub.app/skyline-recovery"
   }
 ]


### PR DESCRIPTION
## Summary
- rename the product experience to Sportshub across metadata, header, footer and CTAs
- refresh the landing content, filters and UI copy to highlight football, padel and boutique fitness offerings
- replace the venue dataset with a curated multi-sport line-up that unlocks richer sport and amenity filters

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency in project)*

------
https://chatgpt.com/codex/tasks/task_e_68dba815958883329747660239a1dd0d