### PR TITLE
Refine filters and rebrand to Sports Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SoccerHUB – Live-Plattform für Indoor-Sporthallen
+# Sports Hub – Live-Plattform für Indoor-Sporthallen
 
-Dieses Projekt ist ein Next.js-14-Aufbau für SoccerHUB – eine deutschlandweite Übersicht über Fußballhallen, Padel-Center und funktionelle Trainingsflächen. Teams vergleichen Flächen, filtern nach Ausstattung und buchen über verifizierte Betreiber:innen.
+Dieses Projekt ist ein Next.js-14-Aufbau für Sports Hub – eine deutschlandweite Übersicht über Fußballhallen, Padel-Center und funktionelle Trainingsflächen. Teams vergleichen Flächen, filtern nach Ausstattung und buchen über verifizierte Betreiber:innen.
 
 ## Quickstart
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,13 +10,13 @@ const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
   title: {
-    default: "SoccerHUB | Indoor-Sporthallen live vergleichen",
-    template: "%s | SoccerHUB",
+    default: "Sports Hub | Indoor-Sporthallen live vergleichen",
+    template: "%s | Sports Hub",
   },
   description:
-    "SoccerHUB bündelt Indoor-Soccer-Arenen, Padel-Courts und funktionelle Trainingsflächen in einer Live-Plattform. Vergleiche Ausstattung, Preise und Verfügbarkeiten und reserviere direkt beim Betreiber.",
+    "Sports Hub bündelt Indoor-Soccer-Arenen, Padel-Courts und funktionelle Trainingsflächen in einer Live-Plattform. Vergleiche Ausstattung, Preise und Verfügbarkeiten und reserviere direkt beim Betreiber.",
   keywords: [
-    "SoccerHUB",
+    "Sports Hub",
     "Fußballhalle",
     "Padel",
     "Indoor Sport",
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
   ],
   metadataBase: new URL("https://sportshub.app"),
   openGraph: {
-    title: "SoccerHUB",
+    title: "Sports Hub",
     description:
       "Die Live-Plattform für Indoor-Sporthallen: Verfügbarkeiten, Ausstattung und Buchungswege auf einen Blick.",
     type: "website",
@@ -49,9 +49,9 @@ export default function RootLayout({
           >
             <div className="container-narrow grid gap-6 text-sm text-[color:var(--text-secondary)] sm:grid-cols-[minmax(0,1fr),auto] sm:items-center">
               <div className="space-y-2">
-                <p className="text-base font-semibold text-[color:var(--text-primary)]">Bleib mit SoccerHUB verbunden</p>
+                <p className="text-base font-semibold text-[color:var(--text-primary)]">Bleib mit Sports Hub verbunden</p>
                 <p>
-                  &copy; {new Date().getFullYear()} SoccerHUB. Crafted für ambitionierte Teams und Betreiber:innen von Henrik und Sharky.
+                  &copy; {new Date().getFullYear()} Sports Hub. Crafted für ambitionierte Teams und Betreiber:innen von Henrik und Sharky.
                 </p>
               </div>
               <div className="flex flex-wrap items-center gap-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default function HomePage() {
               </div>
               <div className="space-y-7">
                 <h1 className="text-4xl font-bold leading-tight text-[color:var(--text-primary)] sm:text-5xl">
-                  SoccerHUB – Dein Live-Überblick über Indoor-Sportanlagen
+                  Sports Hub – Dein Live-Überblick über Indoor-Sportanlagen
                 </h1>
                 <p className="max-w-2xl text-lg text-[color:var(--text-secondary)]/90">
                   Finde in Sekunden die passende Halle für dein Team: von modernen Indoor-Soccer-Arenen über Padel-Courts bis hin zu funktionellen Trainingsflächen. Alle Plätze sind geprüft, mit Live-Verfügbarkeiten, Ausstattung und Buchungslinks.
@@ -138,7 +138,7 @@ export default function HomePage() {
                 <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--accent-primary)]">Hallenkategorien</p>
                 <h2 className="text-3xl font-semibold text-[color:var(--text-primary)]">Strukturiert nach Sportart &amp; Ausstattung</h2>
                 <p className="text-base text-[color:var(--text-secondary)]">
-                  Jede Halle auf SoccerHUB erhält ein kuratiertes Profil mit Fokus auf Spielflächen, Equipment und Services. So findest du schnell den passenden Spot für Training, Turniere oder Corporate Events.
+                  Jede Halle auf Sports Hub erhält ein kuratiertes Profil mit Fokus auf Spielflächen, Equipment und Services. So findest du schnell den passenden Spot für Training, Turniere oder Corporate Events.
                 </p>
               </div>
               <div className="rounded-[2.5rem] border border-[color:var(--surface-glass-border)] bg-[color:var(--surface-card)] p-6 shadow-[0_40px_140px_-90px_rgba(8,36,20,0.75)]">

--- a/components/filter-panel.tsx
+++ b/components/filter-panel.tsx
@@ -67,19 +67,48 @@ interface SectionHeaderProps {
   eyebrow: string;
   title: string;
   description?: string;
+  density: "default" | "compact";
 }
 
-function SectionHeader({ icon, eyebrow, title, description }: SectionHeaderProps) {
+function SectionHeader({ icon, eyebrow, title, description, density }: SectionHeaderProps) {
+  const isCompact = density === "compact";
+
   return (
     <div className="flex items-start gap-3">
-      <span className="mt-0.5 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-[color:var(--accent-primary-strong)]/15 text-[color:var(--accent-primary-strong)] shadow-[0_14px_30px_-20px_rgba(0,108,56,0.45)]">
+      <span
+        className={clsx(
+          "inline-flex flex-shrink-0 items-center justify-center rounded-2xl bg-[color:var(--accent-primary-strong)]/15 text-[color:var(--accent-primary-strong)] shadow-[0_14px_30px_-20px_rgba(0,108,56,0.45)]",
+          isCompact ? "h-8 w-8" : "mt-0.5 h-9 w-9"
+        )}
+      >
         {icon}
       </span>
-      <div className="space-y-1">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-[color:var(--text-tertiary)]">{eyebrow}</p>
-        <h3 className="text-base font-semibold leading-tight text-[color:var(--text-primary)]">{title}</h3>
+      <div className={clsx("space-y-1", isCompact && "space-y-0.5")}>
+        <p
+          className={clsx(
+            "font-semibold uppercase tracking-[0.32em] text-[color:var(--text-tertiary)]",
+            isCompact ? "text-[10px]" : "text-[11px]"
+          )}
+        >
+          {eyebrow}
+        </p>
+        <h3
+          className={clsx(
+            "font-semibold leading-tight text-[color:var(--text-primary)]",
+            isCompact ? "text-sm" : "text-base"
+          )}
+        >
+          {title}
+        </h3>
         {description ? (
-          <p className="text-sm leading-relaxed text-[color:var(--text-secondary)]/80">{description}</p>
+          <p
+            className={clsx(
+              "text-[color:var(--text-secondary)]/80",
+              isCompact ? "text-xs leading-relaxed" : "text-sm leading-relaxed"
+            )}
+          >
+            {description}
+          </p>
         ) : null}
       </div>
     </div>
@@ -95,6 +124,7 @@ export function FilterPanel({
   className,
   density = "default",
 }: FilterPanelProps) {
+  const isCompact = density === "compact";
   const sportOptions = useMemo(() => sportsOptions, [sportsOptions]);
   const [geoState, setGeoState] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [geoMessage, setGeoMessage] = useState<string | null>(null);
@@ -244,122 +274,176 @@ export function FilterPanel({
   return (
     <aside
       className={clsx(
-        "glass-panel theme-transition space-y-7 rounded-3xl border border-[color:var(--border-subtle)]/80 text-[color:var(--text-primary)] backdrop-blur",
-        density === "compact" ? "p-6" : "p-8",
+        "glass-panel theme-transition rounded-3xl border border-[color:var(--border-subtle)]/80 text-[color:var(--text-primary)] backdrop-blur",
+        isCompact ? "space-y-5 p-5 lg:p-6" : "space-y-7 p-8",
         className
       )}
     >
-      <header className="flex items-start justify-between gap-4">
-        <div>
+      <header
+        className={clsx(
+          "flex items-start justify-between gap-4",
+          isCompact && "flex-col sm:flex-row sm:items-start sm:gap-6"
+        )}
+      >
+        <div className={clsx("space-y-2", isCompact && "space-y-1")}>
           <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--accent-primary-strong)]/90">
             Filterübersicht
           </p>
-          <h2 className="mt-2 text-2xl font-semibold leading-tight text-[color:var(--text-primary)]">
-            Finde deinen Spot
+          <h2
+            className={clsx(
+              "font-semibold leading-tight text-[color:var(--text-primary)]",
+              isCompact ? "text-xl" : "mt-2 text-2xl"
+            )}
+          >
+            Dein Sports-Hub Filter
           </h2>
-          <p className="mt-2 text-sm leading-relaxed text-[color:var(--text-secondary)]">
-            Kuratiere Sportarten, Standort und Ausstattung. SoccerHUB zeigt dir live verfügbare Slots, Preise und Add-ons mit
-            einem Blick.
+          <p
+            className={clsx(
+              "text-[color:var(--text-secondary)]",
+              isCompact ? "text-xs leading-relaxed" : "mt-2 text-sm leading-relaxed"
+            )}
+          >
+            Stelle Sportarten, Standort und Ausstattung zusammen. Sports Hub zeigt dir live verfügbare Slots, Preise und Extras.
           </p>
         </div>
         <button
           type="button"
-          className="theme-transition rounded-full border border-transparent px-4 py-2 text-sm font-semibold text-[color:var(--accent-primary)] hover:border-[color:var(--accent-primary)]/40 hover:bg-[color:var(--accent-primary)]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
+          className={clsx(
+            "theme-transition rounded-full border border-transparent font-semibold text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70",
+            isCompact ? "px-4 py-1.5 text-xs" : "px-4 py-2 text-sm hover:border-[color:var(--accent-primary)]/40 hover:bg-[color:var(--accent-primary)]/10"
+          )}
           onClick={onReset}
         >
           Zurücksetzen
         </button>
       </header>
 
-      <div className="space-y-6">
-        <section className="space-y-5 rounded-2xl border border-[color:var(--surface-glass-border)]/85 bg-[color:var(--surface-card-muted)]/70 p-5 shadow-[0_24px_90px_-60px_rgba(8,36,24,0.65)]">
-          <div className="flex items-center justify-between gap-4">
-            <SectionHeader
-              icon={<MapPinIcon className="h-4 w-4" />}
-              eyebrow="Standort"
-              title="Wo willst du spielen?"
-              description="Suche nach Städten oder nutze Near Me für Vorschläge basierend auf deinem Standort."
-            />
-            <button
-              type="button"
-              onClick={handleLocateMe}
-              className="theme-transition inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary-strong)]/40 bg-[color:var(--accent-primary-strong)]/12 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--accent-primary-strong)] hover:bg-[color:var(--accent-primary-strong)]/18 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary-strong)]/70"
-            >
-              <TargetIcon className="h-3.5 w-3.5" />
-              Near Me
-            </button>
-          </div>
-          <label className="relative block">
-            <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
-              <SearchIcon className="h-4 w-4" />
-            </span>
-            <input
-              id="city-filter"
-              type="text"
-              placeholder="Stadt oder Stadtteil suchen"
-              value={state.city}
-              onChange={(event) => onChange({ ...state, city: event.target.value, nearby: false })}
-              className="theme-transition w-full rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/80 py-3 pl-11 pr-4 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40"
-            />
-            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[color:var(--accent-primary-strong)]/85">
-              <MapPinIcon className="h-4 w-4" />
-            </span>
-          </label>
-          {geoMessage ? (
-            <p className={`text-xs font-medium ${geoMessageColor}`}>{geoMessage}</p>
-          ) : (
-            <p className="text-xs text-[color:var(--text-secondary)]/75">Direkt nach Städten suchen oder mit „Near Me“ starten.</p>
-          )}
-        </section>
+      <div className={clsx(isCompact ? "space-y-5" : "space-y-6")}>
+        <div className={clsx(!isCompact && "space-y-6", isCompact && "grid gap-5 lg:grid-cols-2")}> 
+          <section
+            className={clsx(
+              "space-y-5 rounded-2xl border p-5",
+              isCompact
+                ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70 shadow-none"
+                : "border-[color:var(--surface-glass-border)]/85 bg-[color:var(--surface-card-muted)]/70 shadow-[0_24px_90px_-60px_rgba(8,36,24,0.65)]"
+            )}
+          >
+            <div className={clsx("flex items-center justify-between gap-4", isCompact && "flex-wrap gap-3")}> 
+              <SectionHeader
+                icon={<MapPinIcon className="h-4 w-4" />}
+                eyebrow="Standort"
+                title="Wo willst du spielen?"
+                description="Suche nach Städten oder nutze Near Me für Vorschläge basierend auf deinem Standort."
+                density={density}
+              />
+              <button
+                type="button"
+                onClick={handleLocateMe}
+                className={clsx(
+                  "theme-transition inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary-strong)]/40 px-3 font-semibold uppercase tracking-[0.18em] text-[color:var(--accent-primary-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary-strong)]/70",
+                  isCompact
+                    ? "bg-[color:var(--accent-primary-strong)]/10 py-1 text-[10px]"
+                    : "bg-[color:var(--accent-primary-strong)]/12 py-1.5 text-xs hover:bg-[color:var(--accent-primary-strong)]/18"
+                )}
+              >
+                <TargetIcon className="h-3.5 w-3.5" />
+                Near Me
+              </button>
+            </div>
+            <label className="relative block">
+              <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
+                <SearchIcon className="h-4 w-4" />
+              </span>
+              <input
+                id="city-filter"
+                type="text"
+                placeholder="Stadt oder Stadtteil suchen"
+                value={state.city}
+                onChange={(event) => onChange({ ...state, city: event.target.value, nearby: false })}
+                className={clsx(
+                  "theme-transition w-full rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/80 pl-11 pr-4 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
+                  isCompact ? "py-2.5" : "py-3"
+                )}
+              />
+              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[color:var(--accent-primary-strong)]/85">
+                <MapPinIcon className="h-4 w-4" />
+              </span>
+            </label>
+            {geoMessage ? (
+              <p className={`text-xs font-medium ${geoMessageColor}`}>{geoMessage}</p>
+            ) : (
+              <p className="text-xs text-[color:var(--text-secondary)]/75">Direkt nach Städten suchen oder mit „Near Me“ starten.</p>
+            )}
+          </section>
 
-        <section className="space-y-4 rounded-2xl border border-[color:var(--surface-glass-border)]/80 bg-[color:var(--surface-card)]/78 p-5">
-          <div className="flex items-start justify-between gap-4">
-            <SectionHeader
-              icon={<RacketIcon className="h-4 w-4" />}
-              eyebrow="Sportarten"
-              title="Disziplin wählen"
-              description="Kombiniere mehrere Sportarten für multifunktionale Anlagen."
-            />
-            <span className="mt-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--text-secondary)]/75">
-              Mehrfachauswahl
-            </span>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {sportOptions.map((sport) => {
-              const selected = state.sports.includes(sport);
-              return (
-                <button
-                  key={sport}
-                  type="button"
-                  onClick={() => toggleSport(sport)}
-                  aria-pressed={selected}
-                  className={`theme-transition inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)] ${
-                    selected
-                      ? "border-transparent bg-[color:var(--accent-primary-strong)] text-[color:var(--accent-primary-contrast)] shadow-[0_16px_36px_-22px_rgba(0,108,56,0.55)]"
-                      : "border-[color:var(--surface-glass-border)]/60 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary-strong)]/45 hover:text-[color:var(--accent-primary-strong)]"
-                  }`}
-                >
-                  <span
-                    className={`h-1.5 w-1.5 rounded-full ${
+          <section
+            className={clsx(
+              "space-y-4 rounded-2xl border p-5",
+              isCompact
+                ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70"
+                : "border-[color:var(--surface-glass-border)]/80 bg-[color:var(--surface-card)]/78"
+            )}
+          >
+            <div className={clsx("flex items-start justify-between gap-4", isCompact && "flex-wrap gap-2")}>
+              <SectionHeader
+                icon={<RacketIcon className="h-4 w-4" />}
+                eyebrow="Sportarten"
+                title="Disziplin wählen"
+                description="Kombiniere mehrere Sportarten für multifunktionale Anlagen."
+                density={density}
+              />
+              <span className="mt-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--text-secondary)]/75">
+                Mehrfachauswahl
+              </span>
+            </div>
+            <div className={clsx("flex flex-wrap gap-2", isCompact && "gap-1.5")}>
+              {sportOptions.map((sport) => {
+                const selected = state.sports.includes(sport);
+                return (
+                  <button
+                    key={sport}
+                    type="button"
+                    onClick={() => toggleSport(sport)}
+                    aria-pressed={selected}
+                    className={clsx(
+                      "theme-transition inline-flex items-center gap-2 rounded-full border px-4 text-xs font-semibold uppercase tracking-[0.18em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]",
+                      isCompact ? "py-1.5" : "py-2",
                       selected
-                        ? "bg-[color:var(--accent-primary-contrast)]"
-                        : "bg-[color:var(--accent-primary-strong)]/40"
-                    }`}
-                    aria-hidden
-                  />
-                  {sport}
-                </button>
-              );
-            })}
-          </div>
-        </section>
+                        ? "border-transparent bg-[color:var(--accent-primary-strong)] text-[color:var(--accent-primary-contrast)] shadow-[0_16px_36px_-22px_rgba(0,108,56,0.55)]"
+                        : "border-[color:var(--surface-glass-border)]/60 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary-strong)]/45 hover:text-[color:var(--accent-primary-strong)]"
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        "h-1.5 w-1.5 rounded-full",
+                        selected
+                          ? "bg-[color:var(--accent-primary-contrast)]"
+                          : "bg-[color:var(--accent-primary-strong)]/40"
+                      )}
+                      aria-hidden
+                    />
+                    {sport}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </div>
 
-        <section className="grid gap-5 rounded-2xl border border-[color:var(--surface-glass-border)]/85 bg-[color:var(--surface-card-muted)]/70 p-5 sm:grid-cols-2">
+        <section
+          className={clsx(
+            "grid gap-5 rounded-2xl border p-5 sm:grid-cols-2",
+            isCompact
+              ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70"
+              : "border-[color:var(--surface-glass-border)]/85 bg-[color:var(--surface-card-muted)]/70"
+          )}
+        >
           <div className="space-y-3">
             <SectionHeader
               icon={<EuroIcon className="h-4 w-4" />}
               eyebrow="Preisrange"
               title="Budget festlegen"
+              density={density}
             />
             <div className="flex items-center gap-3">
               <div className="relative flex-1">
@@ -379,7 +463,10 @@ export function FilterPanel({
                       priceMin: event.target.value ? Number(event.target.value) : undefined,
                     })
                   }
-                  className="theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/85 py-2 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40"
+                  className={clsx(
+                    "theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/85 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
+                    isCompact ? "py-2" : "py-2"
+                  )}
                 />
               </div>
               <div className="text-xs text-[color:var(--text-secondary)]/70">bis</div>
@@ -400,7 +487,10 @@ export function FilterPanel({
                       priceMax: event.target.value ? Number(event.target.value) : undefined,
                     })
                   }
-                  className="theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/85 py-2 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40"
+                  className={clsx(
+                    "theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/85 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
+                    isCompact ? "py-2" : "py-2"
+                  )}
                 />
               </div>
             </div>
@@ -413,16 +503,19 @@ export function FilterPanel({
               icon={<ClockIcon className="h-4 w-4" />}
               eyebrow="Öffnungszeiten"
               title="Verfügbare Slots"
+              density={density}
             />
             <div className="flex flex-wrap gap-2">
               <button
                 type="button"
                 onClick={() => onChange({ ...state, day: "" })}
-                className={`theme-transition rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] ${
+                className={clsx(
+                  "theme-transition rounded-full px-4 text-xs font-semibold uppercase tracking-[0.18em]",
+                  isCompact ? "py-1.5" : "py-2",
                   !state.day
                     ? "bg-[color:var(--accent-primary)] text-[color:var(--background-primary)]"
                     : "border border-[color:var(--border-subtle)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)]"
-                }`}
+                )}
               >
                 Alle Tage
               </button>
@@ -433,11 +526,13 @@ export function FilterPanel({
                     key={day}
                     type="button"
                     onClick={() => onChange({ ...state, day })}
-                    className={`theme-transition rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] ${
+                    className={clsx(
+                      "theme-transition rounded-full px-4 text-xs font-semibold uppercase tracking-[0.18em]",
+                      isCompact ? "py-1.5" : "py-2",
                       selected
                         ? "bg-[color:var(--accent-secondary)] text-[color:var(--background-primary)]"
                         : "border border-[color:var(--border-subtle)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)]"
-                    }`}
+                    )}
                   >
                     {weekdayLabels[day].slice(0, 2)}
                   </button>
@@ -451,13 +546,21 @@ export function FilterPanel({
           </div>
         </section>
 
-        <section className="space-y-5 rounded-2xl border border-[color:var(--surface-glass-border)]/82 bg-[color:var(--surface-card)]/68 p-5">
-          <div className="flex items-center justify-between gap-4">
+        <section
+          className={clsx(
+            "space-y-5 rounded-2xl border p-5",
+            isCompact
+              ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70"
+              : "border-[color:var(--surface-glass-border)]/82 bg-[color:var(--surface-card)]/68"
+          )}
+        >
+          <div className={clsx("flex items-center justify-between gap-4", isCompact && "flex-wrap gap-2")}>
             <SectionHeader
               icon={<SparkleIcon className="h-4 w-4" />}
               eyebrow="Ausstattung"
               title="Features mit Icon-Guide"
               description="Hebe Essentials wie Duschen oder Premium-Ausstattung wie Videoanalyse hervor."
+              density={density}
             />
             <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-secondary)]/70">
               Tippe zum Aktivieren
@@ -470,7 +573,7 @@ export function FilterPanel({
                 <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--text-secondary)]/70">
                   {group.label}
                 </p>
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <div className={clsx("grid gap-2", isCompact ? "grid-cols-2 xl:grid-cols-3" : "grid-cols-1 sm:grid-cols-2")}>
                   {group.items.map((amenity) => {
                     const selected = state.amenities.includes(amenity);
                     return (
@@ -479,11 +582,13 @@ export function FilterPanel({
                         type="button"
                         onClick={() => toggleAmenity(amenity)}
                         aria-pressed={selected}
-                        className={`theme-transition flex items-center justify-between gap-3 rounded-2xl border px-3.5 py-2.5 text-left text-sm ${
+                        className={clsx(
+                          "theme-transition flex items-center justify-between gap-3 rounded-2xl border px-3.5 text-left text-sm",
+                          isCompact ? "py-2" : "py-2.5",
                           selected
                             ? "border-[color:var(--accent-primary)]/50 bg-[color:var(--accent-primary)]/12 text-[color:var(--accent-primary)] shadow-[0_14px_32px_-28px_rgba(10,90,60,0.6)]"
                             : "border-[color:var(--border-subtle)]/60 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)]"
-                        }`}
+                        )}
                       >
                         <span className="inline-flex items-center gap-3">
                           <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-[color:var(--surface-card-muted)]/80">
@@ -491,11 +596,12 @@ export function FilterPanel({
                           </span>
                           <span className="font-medium">{amenity}</span>
                         </span>
-                          <span
-                            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
-                              selected ? "text-[color:var(--accent-primary)]" : "text-[color:var(--text-secondary)]/60"
-                            }`}
-                          >
+                        <span
+                          className={clsx(
+                            "text-xs font-semibold uppercase tracking-[0.18em]",
+                            selected ? "text-[color:var(--accent-primary)]" : "text-[color:var(--text-secondary)]/60"
+                          )}
+                        >
                           {selected ? "Aktiv" : "+"}
                         </span>
                       </button>
@@ -508,7 +614,12 @@ export function FilterPanel({
         </section>
       </div>
 
-      <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70 px-4 py-3 text-xs text-[color:var(--text-secondary)]">
+      <div
+        className={clsx(
+          "rounded-2xl border border-dashed border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70 text-[color:var(--text-secondary)]",
+          isCompact ? "px-4 py-2 text-[11px]" : "px-4 py-3 text-xs"
+        )}
+      >
         <span className="font-semibold text-[color:var(--accent-primary)]">Tipp:</span> Speichere deine Lieblingsfilter als Shortcut in deinem Profil.
       </div>
     </aside>

--- a/components/filterable-venue-list.tsx
+++ b/components/filterable-venue-list.tsx
@@ -229,6 +229,7 @@ export function FilterableVenueList({ venues, sports, amenities }: FilterableVen
             sportsOptions={sports}
             amenityOptions={amenities}
             state={filters}
+            density="compact"
             onChange={(state) => {
               setFilters(state);
               setVisibleCount(ITEMS_PER_PAGE);
@@ -248,7 +249,7 @@ export function FilterableVenueList({ venues, sports, amenities }: FilterableVen
                 </div>
                 <div className="space-y-2">
                   <h2 className="text-2xl font-semibold leading-tight text-[color:var(--text-primary)] sm:text-3xl">
-                    {sortedVenues.length} Hallen im SoccerHUB
+                    {sortedVenues.length} Hallen im Sports Hub
                   </h2>
                   <p className="text-sm leading-relaxed text-[color:var(--text-secondary)]">
                     Filtere nach Sportarten, Preisen und Features. Sortiere nach Preis oder Name und öffne die Kartenansicht für eine visuelle Auswahl.

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -39,9 +39,9 @@ export function SiteHeader() {
               <span className="relative font-black">SH</span>
             </span>
             <span className="flex flex-col leading-tight">
-              <span>SoccerHUB</span>
+              <span>Sports Hub</span>
               <span className="text-xs font-medium uppercase tracking-[0.3em] text-[color:var(--text-secondary)]">
-                Indoor Soccer · Padel · Fitness
+                Indoor Sports · Padel · Fitness
               </span>
             </span>
           </Link>

--- a/components/venue-detail.tsx
+++ b/components/venue-detail.tsx
@@ -201,7 +201,7 @@ export function VenueDetail({ venue }: VenueDetailProps) {
               href="mailto:partners@sportshub.app"
               className="theme-transition inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--accent-primary)] hover:text-[color:var(--accent-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]/70"
             >
-              Betreiber:in? SoccerHUB Partner werden
+              Betreiber:in? Sports Hub Partner werden
             </Link>
           </div>
         </aside>

--- a/docs/soccerhub-platform-style-guide.md
+++ b/docs/soccerhub-platform-style-guide.md
@@ -1,4 +1,4 @@
-# SoccerHUB Plattform – Layout & Style Guide
+# Sports Hub Plattform – Layout & Style Guide
 
 ## Kontrast & Typografie
 - Headlines: `--text-primary` (#F4FFF7) auf dunklem Glas-Hintergrund (`--surface-card`), Mindest-Kontrastverhältnis 4.8:1.

--- a/docs/sportshub-style-guide.md
+++ b/docs/sportshub-style-guide.md
@@ -1,4 +1,4 @@
-# SoccerHUB UI Style Guide
+# Sports Hub UI Style Guide
 
 Die folgenden Richtlinien dokumentieren das visuelle Redesign der Venue-Übersicht. Sie dienen als Referenz für Produkt-, Design- und Engineering-Teams.
 


### PR DESCRIPTION
## Summary
- Rebrand the app and marketing copy from "SoccerHUB" to "Sports Hub" across metadata, hero content, navigation and docs
- Compact the filter panel with density-aware styling and multi-column layout to reduce visual noise on desktop
- Update the venue list summary and partner CTA copy to reflect the new naming

## Testing
- `npm run lint` *(fails: missing dependency eslint-plugin-react-hooks in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbca9d9c6c83329ffcec7239fb238f