### PR TITLE
Fix Google Map rendering after script load

### DIFF
--- a/components/google-map-canvas.tsx
+++ b/components/google-map-canvas.tsx
@@ -92,7 +92,7 @@ export function GoogleMapCanvas({
   }, [ensureScript, apiKey]);
 
   useEffect(() => {
-    if (!apiKey || !containerRef.current || !window.google?.maps) {
+    if (!apiKey || !containerRef.current || !window.google?.maps || !isScriptLoaded) {
       return;
     }
 
@@ -147,7 +147,7 @@ export function GoogleMapCanvas({
       map.panTo({ lat: coordinate.lat, lng: coordinate.lng });
       map.setZoom(Math.max(map.getZoom(), 11));
     }
-  }, [apiKey, venuePoints, activeCity]);
+  }, [apiKey, venuePoints, activeCity, isScriptLoaded]);
 
   useEffect(() => {
     if (!mapRef.current || !window.google?.maps || venuePoints.length === 0 || !selectedVenueId) {


### PR DESCRIPTION
## Summary
- ensure the Google Map initialization effect waits for the Google script to load before running
- re-run the effect once the script has finished loading so markers render correctly

## Testing
- `npm run lint` *(fails: missing dependency eslint-plugin-react-hooks in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2a715c0c833297ef475272a40426