### PR TITLE
Refine UI glass styling and collapsible filters

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function HomePage() {
               </div>
 
               <div className="space-y-4">
-                <h1 className="text-4xl font-bold leading-tight text-[color:var(--text-primary)] sm:text-5xl">
+                <h1 className="text-4xl font-bold leading-tight text-[color:var(--text-primary)] break-words hyphens-auto sm:text-5xl">
                   Sports Hub – Dein Live-Überblick über Indoor-Sportanlagen
                 </h1>
                 <p className="max-w-2xl text-lg text-[color:var(--text-secondary)]/90">
@@ -96,7 +96,7 @@ export default function HomePage() {
             <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr),360px] lg:items-start">
               <div className="space-y-4">
                 <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--accent-primary)]">Hallenkategorien</p>
-                <h2 className="text-3xl font-semibold text-[color:var(--text-primary)]">Strukturiert nach Sportart &amp; Ausstattung</h2>
+                <h2 className="text-3xl font-semibold text-[color:var(--text-primary)] break-words hyphens-auto">Strukturiert nach Sportart &amp; Ausstattung</h2>
                 <p className="text-base text-[color:var(--text-secondary)]">
                   Kuratierte Profile mit Fokus auf Spielflächen, Equipment und Services. Ideal für Training, Turniere oder Corporate Events.
                 </p>
@@ -157,7 +157,7 @@ export default function HomePage() {
           <div className="relative grid gap-10 lg:grid-cols-[minmax(0,1fr),320px]">
             <div className="space-y-8">
               <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr),minmax(0,320px)] sm:items-center">
-                <h2 className="text-3xl font-semibold text-[color:var(--text-primary)]">So funktioniert die Hallen-Suche</h2>
+                <h2 className="text-3xl font-semibold text-[color:var(--text-primary)] break-words hyphens-auto">So funktioniert die Hallen-Suche</h2>
                 <p className="text-base text-[color:var(--text-secondary)]">
                   Filtere nach Sportart, Fläche, Ausstattung – erhalte sofort passende Ergebnisse. Jedes Profil mit Preisfenster, Auslastung, Extras und Direktbuchung.
                 </p>

--- a/components/filter-panel.tsx
+++ b/components/filter-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useId, useMemo, useState } from "react";
 import clsx from "clsx";
 import {
   AccessibilityIcon,
@@ -18,6 +18,7 @@ import {
   ParkingIcon,
   PoolIcon,
   RacketIcon,
+  ChevronDownIcon,
   SaunaIcon,
   SearchIcon,
   ShowerIcon,
@@ -94,7 +95,7 @@ function SectionHeader({ icon, eyebrow, title, description, density }: SectionHe
         </p>
         <h3
           className={clsx(
-            "font-semibold leading-tight text-[color:var(--text-primary)]",
+            "font-semibold leading-tight text-[color:var(--text-primary)] break-words hyphens-auto",
             isCompact ? "text-sm" : "text-base"
           )}
         >
@@ -103,7 +104,7 @@ function SectionHeader({ icon, eyebrow, title, description, density }: SectionHe
         {description ? (
           <p
             className={clsx(
-              "text-[color:var(--text-secondary)]/80",
+              "text-[color:var(--text-secondary)]/80 break-words hyphens-auto",
               isCompact ? "text-xs leading-relaxed" : "text-sm leading-relaxed"
             )}
           >
@@ -112,6 +113,99 @@ function SectionHeader({ icon, eyebrow, title, description, density }: SectionHe
         ) : null}
       </div>
     </div>
+  );
+}
+
+interface CollapsibleSectionProps {
+  icon: ReactNode;
+  eyebrow: string;
+  title: string;
+  description?: string;
+  density: "default" | "compact";
+  summary?: string;
+  actions?: ReactNode;
+  defaultOpen?: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+function CollapsibleSection({
+  icon,
+  eyebrow,
+  title,
+  description,
+  density,
+  summary,
+  actions,
+  defaultOpen = false,
+  children,
+  className,
+}: CollapsibleSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const isCompact = density === "compact";
+  const contentId = useId();
+
+  return (
+    <section
+      className={clsx(
+        "theme-transition rounded-2xl border border-[color:var(--surface-glass-border)]/65 bg-[linear-gradient(145deg,rgba(255,255,255,0.6),rgba(200,238,220,0.38))] p-5 shadow-[0_32px_120px_-80px_rgba(12,72,48,0.45)] backdrop-blur-xl",
+        className
+      )}
+    >
+      <div
+        className={clsx(
+          "flex w-full flex-col gap-3 sm:flex-row sm:items-start sm:justify-between",
+          isCompact && "gap-2"
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          className={clsx(
+            "group flex flex-1 items-center justify-between gap-3 text-left",
+            isCompact ? "flex-col sm:flex-row sm:items-center" : "flex-wrap"
+          )}
+        >
+          <div className={clsx("flex-1 space-y-2", isCompact && "w-full")}>
+            <SectionHeader
+              icon={icon}
+              eyebrow={eyebrow}
+              title={title}
+              description={description}
+              density={density}
+            />
+            {summary ? (
+              <p className="text-xs font-medium uppercase tracking-[0.24em] text-[color:var(--text-secondary)]/75 break-words hyphens-auto">
+                {summary}
+              </p>
+            ) : null}
+          </div>
+          <ChevronDownIcon
+            className={clsx(
+              "h-4 w-4 flex-shrink-0 text-[color:var(--text-secondary)] transition-transform duration-300",
+              isOpen ? "rotate-180 text-[color:var(--accent-primary-strong)]" : ""
+            )}
+            aria-hidden
+          />
+        </button>
+        {actions ? (
+          <div className="flex flex-shrink-0 items-center gap-2 sm:pt-1">{actions}</div>
+        ) : null}
+      </div>
+      {isOpen ? (
+        <div
+          id={contentId}
+          className={clsx(
+            "mt-4 space-y-4 border-t border-[color:var(--surface-glass-border)]/45 pt-4",
+            isCompact && "mt-3 pt-3"
+          )}
+        >
+          {children}
+        </div>
+      ) : null}
+    </section>
   );
 }
 
@@ -271,10 +365,44 @@ export function FilterPanel({
     }
   };
 
+  const formatPrice = (value: number) =>
+    new Intl.NumberFormat("de-DE", {
+      style: "currency",
+      currency: "EUR",
+      maximumFractionDigits: 0,
+    }).format(value);
+
+  const locationSummary = state.nearby
+    ? "Near Me aktiv"
+    : state.city
+      ? state.city
+      : "Alle Standorte";
+
+  const sportSummary = state.sports.length
+    ? `${state.sports.slice(0, 2).join(" · ")}${state.sports.length > 2 ? ` +${state.sports.length - 2}` : ""}`
+    : "Alle Sportarten";
+
+  const priceSummaryParts: string[] = [];
+  if (typeof state.priceMin === "number" && typeof state.priceMax === "number") {
+    priceSummaryParts.push(`${formatPrice(state.priceMin)} – ${formatPrice(state.priceMax)}`);
+  } else if (typeof state.priceMin === "number") {
+    priceSummaryParts.push(`ab ${formatPrice(state.priceMin)}`);
+  } else if (typeof state.priceMax === "number") {
+    priceSummaryParts.push(`bis ${formatPrice(state.priceMax)}`);
+  }
+  if (state.day) {
+    priceSummaryParts.push(weekdayLabels[state.day]);
+  }
+  const priceSummary = priceSummaryParts.length > 0 ? priceSummaryParts.join(" · ") : "Standardfilter aktiv";
+
+  const amenitiesSummary = state.amenities.length
+    ? `${state.amenities.length} Auswahl${state.amenities.length > 1 ? "en" : ""}`
+    : "Keine Auswahl aktiv";
+
   return (
     <aside
       className={clsx(
-        "glass-panel theme-transition rounded-3xl border border-[color:var(--border-subtle)]/80 text-[color:var(--text-primary)] backdrop-blur",
+        "glass-panel theme-transition rounded-3xl border border-[color:var(--border-subtle)]/75 bg-[linear-gradient(150deg,rgba(255,255,255,0.58),rgba(198,239,219,0.35))] text-[color:var(--text-primary)] shadow-[0_60px_190px_-110px_rgba(12,72,48,0.55)] backdrop-blur-2xl",
         isCompact ? "space-y-5 p-5 lg:p-6" : "space-y-7 p-8",
         className
       )}
@@ -291,7 +419,7 @@ export function FilterPanel({
           </p>
           <h2
             className={clsx(
-              "font-semibold leading-tight text-[color:var(--text-primary)]",
+              "font-semibold leading-tight text-[color:var(--text-primary)] break-words hyphens-auto",
               isCompact ? "text-xl" : "mt-2 text-2xl"
             )}
           >
@@ -299,7 +427,7 @@ export function FilterPanel({
           </h2>
           <p
             className={clsx(
-              "text-[color:var(--text-secondary)]",
+              "text-[color:var(--text-secondary)] break-words hyphens-auto",
               isCompact ? "text-xs leading-relaxed" : "mt-2 text-sm leading-relaxed"
             )}
           >
@@ -318,262 +446,229 @@ export function FilterPanel({
         </button>
       </header>
 
-      <div className={clsx(isCompact ? "space-y-5" : "space-y-6")}>
-        <div className={clsx(!isCompact && "space-y-6", isCompact && "grid gap-5 lg:grid-cols-2")}> 
-          <section
-            className={clsx(
-              "space-y-5 rounded-2xl border p-5",
-              isCompact
-                ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70 shadow-none"
-                : "border-[color:var(--surface-glass-border)]/85 bg-[color:var(--surface-card-muted)]/70 shadow-[0_24px_90px_-60px_rgba(8,36,24,0.65)]"
-            )}
-          >
-            <div className={clsx("flex items-center justify-between gap-4", isCompact && "flex-wrap gap-3")}> 
-              <SectionHeader
-                icon={<MapPinIcon className="h-4 w-4" />}
-                eyebrow="Standort"
-                title="Wo willst du spielen?"
-                description="Suche nach Städten oder nutze Near Me für Vorschläge basierend auf deinem Standort."
-                density={density}
-              />
-              <button
-                type="button"
-                onClick={handleLocateMe}
-                className={clsx(
-                  "theme-transition inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary-strong)]/40 px-3 font-semibold uppercase tracking-[0.18em] text-[color:var(--accent-primary-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary-strong)]/70",
-                  isCompact
-                    ? "bg-[color:var(--accent-primary-strong)]/10 py-1 text-[10px]"
-                    : "bg-[color:var(--accent-primary-strong)]/12 py-1.5 text-xs hover:bg-[color:var(--accent-primary-strong)]/18"
-                )}
-              >
-                <TargetIcon className="h-3.5 w-3.5" />
-                Near Me
-              </button>
-            </div>
-            <label className="relative block">
-              <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
-                <SearchIcon className="h-4 w-4" />
-              </span>
-              <input
-                id="city-filter"
-                type="text"
-                placeholder="Stadt oder Stadtteil suchen"
-                value={state.city}
-                onChange={(event) => onChange({ ...state, city: event.target.value, nearby: false })}
-                className={clsx(
-                  "theme-transition w-full rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/80 pl-11 pr-4 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
-                  isCompact ? "py-2.5" : "py-3"
-                )}
-              />
-              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[color:var(--accent-primary-strong)]/85">
-                <MapPinIcon className="h-4 w-4" />
-              </span>
-            </label>
-            {geoMessage ? (
-              <p className={`text-xs font-medium ${geoMessageColor}`}>{geoMessage}</p>
-            ) : (
-              <p className="text-xs text-[color:var(--text-secondary)]/75">Direkt nach Städten suchen oder mit „Near Me“ starten.</p>
-            )}
-          </section>
-
-          <section
-            className={clsx(
-              "space-y-4 rounded-2xl border p-5",
-              isCompact
-                ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70"
-                : "border-[color:var(--surface-glass-border)]/80 bg-[color:var(--surface-card)]/78"
-            )}
-          >
-            <div className={clsx("flex items-start justify-between gap-4", isCompact && "flex-wrap gap-2")}>
-              <SectionHeader
-                icon={<RacketIcon className="h-4 w-4" />}
-                eyebrow="Sportarten"
-                title="Disziplin wählen"
-                description="Kombiniere mehrere Sportarten für multifunktionale Anlagen."
-                density={density}
-              />
-              <span className="mt-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--text-secondary)]/75">
-                Mehrfachauswahl
-              </span>
-            </div>
-            <div className={clsx("flex flex-wrap gap-2", isCompact && "gap-1.5")}>
-              {sportOptions.map((sport) => {
-                const selected = state.sports.includes(sport);
-                return (
-                  <button
-                    key={sport}
-                    type="button"
-                    onClick={() => toggleSport(sport)}
-                    aria-pressed={selected}
-                    className={clsx(
-                      "theme-transition inline-flex items-center gap-2 rounded-full border px-4 text-xs font-semibold uppercase tracking-[0.18em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]",
-                      isCompact ? "py-1.5" : "py-2",
-                      selected
-                        ? "border-transparent bg-[color:var(--accent-primary-strong)] text-[color:var(--accent-primary-contrast)] shadow-[0_16px_36px_-22px_rgba(0,108,56,0.55)]"
-                        : "border-[color:var(--surface-glass-border)]/60 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary-strong)]/45 hover:text-[color:var(--accent-primary-strong)]"
-                    )}
-                  >
-                    <span
-                      className={clsx(
-                        "h-1.5 w-1.5 rounded-full",
-                        selected
-                          ? "bg-[color:var(--accent-primary-contrast)]"
-                          : "bg-[color:var(--accent-primary-strong)]/40"
-                      )}
-                      aria-hidden
-                    />
-                    {sport}
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-        </div>
-
-        <section
-          className={clsx(
-            "grid gap-5 rounded-2xl border p-5 sm:grid-cols-2",
-            isCompact
-              ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70"
-              : "border-[color:var(--surface-glass-border)]/85 bg-[color:var(--surface-card-muted)]/70"
-          )}
+      <div className="space-y-5">
+        <CollapsibleSection
+          icon={<MapPinIcon className="h-4 w-4" />}
+          eyebrow="Standort"
+          title="Wo willst du spielen?"
+          description="Suche nach Städten oder nutze Near Me für Vorschläge basierend auf deinem Standort."
+          density={density}
+          summary={locationSummary}
+          actions={
+            <button
+              type="button"
+              onClick={handleLocateMe}
+              className={clsx(
+                "theme-transition inline-flex items-center gap-2 rounded-full border border-[color:var(--accent-primary-strong)]/40 px-3 font-semibold uppercase tracking-[0.18em] text-[color:var(--accent-primary-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary-strong)]/70",
+                isCompact ? "bg-[color:var(--accent-primary-strong)]/12 py-1 text-[10px]" : "bg-[color:var(--accent-primary-strong)]/14 py-1.5 text-xs hover:bg-[color:var(--accent-primary-strong)]/20"
+              )}
+            >
+              <TargetIcon className="h-3.5 w-3.5" />
+              Near Me
+            </button>
+          }
+          defaultOpen
         >
-          <div className="space-y-3">
-            <SectionHeader
-              icon={<EuroIcon className="h-4 w-4" />}
-              eyebrow="Preisrange"
-              title="Budget festlegen"
-              density={density}
+          <label className="relative block">
+            <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
+              <SearchIcon className="h-4 w-4" />
+            </span>
+            <input
+              id="city-filter"
+              type="text"
+              placeholder="Stadt oder Stadtteil suchen"
+              value={state.city}
+              onChange={(event) => onChange({ ...state, city: event.target.value, nearby: false })}
+              className={clsx(
+                "theme-transition w-full rounded-full border border-[color:var(--border-subtle)]/80 bg-white/80 pl-11 pr-4 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
+                isCompact ? "py-2.5" : "py-3"
+              )}
             />
-            <div className="flex items-center gap-3">
-              <div className="relative flex-1">
-                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
-                  <EuroIcon className="h-4 w-4" />
-                </span>
-                <input
-                  id="price-min"
-                  type="number"
-                  min={0}
-                  inputMode="numeric"
-                  placeholder="Min"
-                  value={state.priceMin ?? ""}
-                  onChange={(event) =>
-                    onChange({
-                      ...state,
-                      priceMin: event.target.value ? Number(event.target.value) : undefined,
-                    })
-                  }
-                  className={clsx(
-                    "theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/85 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
-                    isCompact ? "py-2" : "py-2"
-                  )}
-                />
-              </div>
-              <div className="text-xs text-[color:var(--text-secondary)]/70">bis</div>
-              <div className="relative flex-1">
-                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
-                  <EuroIcon className="h-4 w-4" />
-                </span>
-                <input
-                  id="price-max"
-                  type="number"
-                  min={0}
-                  inputMode="numeric"
-                  placeholder="Max"
-                  value={state.priceMax ?? ""}
-                  onChange={(event) =>
-                    onChange({
-                      ...state,
-                      priceMax: event.target.value ? Number(event.target.value) : undefined,
-                    })
-                  }
-                  className={clsx(
-                    "theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-card)]/85 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
-                    isCompact ? "py-2" : "py-2"
-                  )}
-                />
-              </div>
-            </div>
+            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[color:var(--accent-primary-strong)]/85">
+              <MapPinIcon className="h-4 w-4" />
+            </span>
+          </label>
+          {geoMessage ? (
+            <p className={`text-xs font-medium ${geoMessageColor}`}>{geoMessage}</p>
+          ) : (
             <p className="text-xs text-[color:var(--text-secondary)]/75">
-              Typische Buchungsfenster liegen zwischen 45&nbsp;€ und 70&nbsp;€ pro Stunde.
+              Direkt nach Städten suchen oder mit „Near Me“ starten.
             </p>
-          </div>
-          <div className="space-y-3">
-            <SectionHeader
-              icon={<ClockIcon className="h-4 w-4" />}
-              eyebrow="Öffnungszeiten"
-              title="Verfügbare Slots"
-              density={density}
-            />
-            <div className="flex flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={() => onChange({ ...state, day: "" })}
-                className={clsx(
-                  "theme-transition rounded-full px-4 text-xs font-semibold uppercase tracking-[0.18em]",
-                  isCompact ? "py-1.5" : "py-2",
-                  !state.day
-                    ? "bg-[color:var(--accent-primary)] text-[color:var(--background-primary)]"
-                    : "border border-[color:var(--border-subtle)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)]"
-                )}
-              >
-                Alle Tage
-              </button>
-              {(Object.keys(weekdayLabels) as Weekday[]).map((day) => {
-                const selected = state.day === day;
-                return (
-                  <button
-                    key={day}
-                    type="button"
-                    onClick={() => onChange({ ...state, day })}
-                    className={clsx(
-                      "theme-transition rounded-full px-4 text-xs font-semibold uppercase tracking-[0.18em]",
-                      isCompact ? "py-1.5" : "py-2",
-                      selected
-                        ? "bg-[color:var(--accent-secondary)] text-[color:var(--background-primary)]"
-                        : "border border-[color:var(--border-subtle)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)]"
-                    )}
-                  >
-                    {weekdayLabels[day].slice(0, 2)}
-                  </button>
-                );
-              })}
-            </div>
-            <p className="flex items-center gap-2 text-xs text-[color:var(--text-secondary)]/75">
-              <ClockIcon className="h-4 w-4" />
-              Zeigt nur Hallen an, die am gewählten Tag Slots anbieten.
-            </p>
-          </div>
-        </section>
-
-        <section
-          className={clsx(
-            "space-y-5 rounded-2xl border p-5",
-            isCompact
-              ? "border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70"
-              : "border-[color:var(--surface-glass-border)]/82 bg-[color:var(--surface-card)]/68"
           )}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          icon={<RacketIcon className="h-4 w-4" />}
+          eyebrow="Sportarten"
+          title="Disziplin wählen"
+          description="Kombiniere mehrere Sportarten für multifunktionale Anlagen."
+          density={density}
+          summary={sportSummary}
+          actions={
+            <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--text-secondary)]/75">
+              Mehrfachauswahl
+            </span>
+          }
         >
-          <div className={clsx("flex items-center justify-between gap-4", isCompact && "flex-wrap gap-2")}>
-            <SectionHeader
-              icon={<SparkleIcon className="h-4 w-4" />}
-              eyebrow="Ausstattung"
-              title="Features mit Icon-Guide"
-              description="Hebe Essentials wie Duschen oder Premium-Ausstattung wie Videoanalyse hervor."
-              density={density}
-            />
+          <div className={clsx("flex flex-wrap gap-2", isCompact && "gap-1.5")}>
+            {sportOptions.map((sport) => {
+              const selected = state.sports.includes(sport);
+              return (
+                <button
+                  key={sport}
+                  type="button"
+                  onClick={() => toggleSport(sport)}
+                  aria-pressed={selected}
+                  className={clsx(
+                    "theme-transition inline-flex items-center gap-2 rounded-full border px-4 text-xs font-semibold uppercase tracking-[0.18em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]",
+                    isCompact ? "py-1.5" : "py-2",
+                    selected
+                      ? "border-transparent bg-[color:var(--accent-primary-strong)] text-[color:var(--accent-primary-contrast)] shadow-[0_16px_36px_-22px_rgba(0,108,56,0.55)]"
+                      : "border-[color:var(--surface-glass-border)]/55 bg-white/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary-strong)]/45 hover:text-[color:var(--accent-primary-strong)]"
+                  )}
+                >
+                  <span
+                    className={clsx(
+                      "h-1.5 w-1.5 rounded-full",
+                      selected
+                        ? "bg-[color:var(--accent-primary-contrast)]"
+                        : "bg-[color:var(--accent-primary-strong)]/40"
+                    )}
+                    aria-hidden
+                  />
+                  {sport}
+                </button>
+              );
+            })}
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          icon={<EuroIcon className="h-4 w-4" />}
+          eyebrow="Zeit & Budget"
+          title="Budget & Slots feinjustieren"
+          description="Setze Rahmen für Preise und verfügbare Tage."
+          density={density}
+          summary={priceSummary}
+        >
+          <div className={clsx("grid gap-4", isCompact ? "sm:grid-cols-1" : "sm:grid-cols-2")}> 
+            <div className="rounded-2xl border border-[color:var(--surface-glass-border)]/60 bg-white/80 p-4 shadow-[0_20px_70px_-60px_rgba(12,72,48,0.45)]">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--text-tertiary)]">
+                Preisrange
+              </p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="relative flex-1">
+                  <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
+                    <EuroIcon className="h-4 w-4" />
+                  </span>
+                  <input
+                    id="price-min"
+                    type="number"
+                    min={0}
+                    inputMode="numeric"
+                    placeholder="Min"
+                    value={state.priceMin ?? ""}
+                    onChange={(event) =>
+                      onChange({
+                        ...state,
+                        priceMin: event.target.value ? Number(event.target.value) : undefined,
+                      })
+                    }
+                    className="theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/80 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40 py-2"
+                  />
+                </div>
+                <div className="text-xs text-[color:var(--text-secondary)]/70">bis</div>
+                <div className="relative flex-1">
+                  <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)]/70">
+                    <EuroIcon className="h-4 w-4" />
+                  </span>
+                  <input
+                    id="price-max"
+                    type="number"
+                    min={0}
+                    inputMode="numeric"
+                    placeholder="Max"
+                    value={state.priceMax ?? ""}
+                    onChange={(event) =>
+                      onChange({
+                        ...state,
+                        priceMax: event.target.value ? Number(event.target.value) : undefined,
+                      })
+                    }
+                    className="theme-transition w-full rounded-2xl border border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/80 pl-10 pr-3 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40 py-2"
+                  />
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-[color:var(--text-secondary)]/75">
+                Typische Buchungsfenster liegen zwischen 45&nbsp;€ und 70&nbsp;€ pro Stunde.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-[color:var(--surface-glass-border)]/60 bg-white/80 p-4 shadow-[0_20px_70px_-60px_rgba(12,72,48,0.45)]">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--text-tertiary)]">
+                Öffnungszeiten
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => onChange({ ...state, day: "" })}
+                  className={clsx(
+                    "theme-transition rounded-full px-4 text-xs font-semibold uppercase tracking-[0.18em]",
+                    isCompact ? "py-1.5" : "py-2",
+                    !state.day
+                      ? "bg-[color:var(--accent-primary)] text-[color:var(--background-primary)]"
+                      : "border border-[color:var(--border-subtle)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)]"
+                  )}
+                >
+                  Alle Tage
+                </button>
+                {(Object.keys(weekdayLabels) as Weekday[]).map((day) => {
+                  const selected = state.day === day;
+                  return (
+                    <button
+                      key={day}
+                      type="button"
+                      onClick={() => onChange({ ...state, day })}
+                      className={clsx(
+                        "theme-transition rounded-full px-4 text-xs font-semibold uppercase tracking-[0.18em]",
+                        isCompact ? "py-1.5" : "py-2",
+                        selected
+                          ? "bg-[color:var(--accent-secondary)] text-[color:var(--background-primary)]"
+                          : "border border-[color:var(--border-subtle)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)]"
+                      )}
+                    >
+                      {weekdayLabels[day].slice(0, 2)}
+                    </button>
+                  );
+                })}
+              </div>
+              <p className="mt-3 flex items-center gap-2 text-xs text-[color:var(--text-secondary)]/75">
+                <ClockIcon className="h-4 w-4" />
+                Zeigt nur Hallen an, die am gewählten Tag Slots anbieten.
+              </p>
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          icon={<SparkleIcon className="h-4 w-4" />}
+          eyebrow="Ausstattung"
+          title="Features mit Icon-Guide"
+          description="Hebe Essentials wie Duschen oder Premium-Ausstattung wie Videoanalyse hervor."
+          density={density}
+          summary={amenitiesSummary}
+          actions={
             <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-secondary)]/70">
               Tippe zum Aktivieren
             </span>
-          </div>
-
+          }
+        >
           <div className="space-y-4">
             {amenityGroups.map((group) => (
               <div key={group.label} className="space-y-3">
                 <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--text-secondary)]/70">
                   {group.label}
                 </p>
-                <div className={clsx("grid gap-2", isCompact ? "grid-cols-2 xl:grid-cols-3" : "grid-cols-1 sm:grid-cols-2")}>
+                <div className={clsx("grid gap-2", isCompact ? "grid-cols-2 xl:grid-cols-3" : "grid-cols-1 sm:grid-cols-2")}> 
                   {group.items.map((amenity) => {
                     const selected = state.amenities.includes(amenity);
                     return (
@@ -586,15 +681,15 @@ export function FilterPanel({
                           "theme-transition flex items-center justify-between gap-3 rounded-2xl border px-3.5 text-left text-sm",
                           isCompact ? "py-2" : "py-2.5",
                           selected
-                            ? "border-[color:var(--accent-primary)]/50 bg-[color:var(--accent-primary)]/12 text-[color:var(--accent-primary)] shadow-[0_14px_32px_-28px_rgba(10,90,60,0.6)]"
-                            : "border-[color:var(--border-subtle)]/60 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)]"
+                            ? "border-[color:var(--accent-primary)]/55 bg-[color:var(--accent-primary)]/14 text-[color:var(--accent-primary)] shadow-[0_14px_32px_-28px_rgba(10,90,60,0.6)]"
+                            : "border-[color:var(--border-subtle)]/60 bg-white/75 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)]"
                         )}
                       >
                         <span className="inline-flex items-center gap-3">
-                          <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-[color:var(--surface-card-muted)]/80">
+                          <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-[color:var(--surface-card-muted)]/80 text-[color:var(--accent-primary)]">
                             {getAmenityIcon(amenity)}
                           </span>
-                          <span className="font-medium">{amenity}</span>
+                          <span className="font-medium break-words hyphens-auto">{amenity}</span>
                         </span>
                         <span
                           className={clsx(
@@ -611,12 +706,11 @@ export function FilterPanel({
               </div>
             ))}
           </div>
-        </section>
+        </CollapsibleSection>
       </div>
-
       <div
         className={clsx(
-          "rounded-2xl border border-dashed border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/70 text-[color:var(--text-secondary)]",
+          "rounded-2xl border border-dashed border-[color:var(--border-subtle)]/60 bg-white/80 text-[color:var(--text-secondary)] backdrop-blur",
           isCompact ? "px-4 py-2 text-[11px]" : "px-4 py-3 text-xs"
         )}
       >

--- a/components/google-map-canvas.tsx
+++ b/components/google-map-canvas.tsx
@@ -251,8 +251,8 @@ export function GoogleMapCanvas({
   const shouldRenderFallback = !apiKey || !!scriptError || !isScriptLoaded;
 
   return (
-    <div className="relative h-full min-h-[420px] overflow-hidden rounded-3xl border border-[color:var(--surface-glass-border)]/90 bg-[linear-gradient(160deg,rgba(7,34,23,0.85),rgba(4,20,12,0.92))]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(62,202,130,0.25),transparent_55%)]" aria-hidden />
+    <div className="relative h-full min-h-[420px] overflow-hidden rounded-3xl border border-[color:var(--surface-glass-border)]/70 bg-[linear-gradient(155deg,rgba(255,255,255,0.82),rgba(204,239,222,0.78))] shadow-[0_45px_160px_-100px_rgba(12,78,48,0.55)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(64,196,130,0.22),transparent_60%)]" aria-hidden />
       {shouldRenderFallback ? (
         <FallbackMap
           points={venuePoints}
@@ -265,12 +265,12 @@ export function GoogleMapCanvas({
         <div ref={containerRef} className="absolute inset-0" role="presentation" />
       )}
       {!apiKey && (
-        <div className="pointer-events-none absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-black/50 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white">
+        <div className="pointer-events-none absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--accent-primary-strong)] shadow-[0_12px_32px_-20px_rgba(12,74,48,0.45)]">
           Demo-Modus ohne API-Key
         </div>
       )}
       {scriptError ? (
-        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--accent-secondary)]/40 bg-black/60 px-4 py-3 text-sm text-white">
+        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--accent-secondary)]/40 bg-white/80 px-4 py-3 text-sm text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(12,78,48,0.45)]">
           {scriptError}
         </div>
       ) : null}
@@ -302,10 +302,10 @@ function FallbackMap({ points, activeCity, selectedVenueId, onMarkerSelect, erro
         {[...Array(6)].map((_, index) => (
           <div key={`grid-${index}`} className="absolute inset-0">
             <div className="absolute inset-x-0" style={{ top: `${(index + 1) * 16}%` }}>
-              <div className="h-px w-full bg-white/8" />
+              <div className="h-px w-full bg-[color:var(--accent-primary)]/25" />
             </div>
             <div className="absolute inset-y-0" style={{ left: `${(index + 1) * 16}%` }}>
-              <div className="h-full w-px bg-white/8" />
+              <div className="h-full w-px bg-[color:var(--accent-primary)]/25" />
             </div>
           </div>
         ))}
@@ -324,36 +324,42 @@ function FallbackMap({ points, activeCity, selectedVenueId, onMarkerSelect, erro
             key={point.venue.id}
             type="button"
             style={{ top: `${top}%`, left: `${left}%` }}
-            className={`theme-transition absolute -translate-x-1/2 -translate-y-full rounded-2xl border px-4 py-3 text-left shadow-[0_22px_60px_-40px_rgba(5,64,38,0.9)] backdrop-blur ${
+            className={`theme-transition absolute -translate-x-1/2 -translate-y-full rounded-2xl border px-4 py-3 text-left shadow-[0_26px_70px_-42px_rgba(16,88,60,0.55)] backdrop-blur ${
               isSelected
-                ? "border-[color:var(--accent-primary-strong)] bg-[color:var(--accent-primary-strong)]/85 text-[color:var(--accent-primary-contrast)]"
-                : "border-white/18 bg-white/14 text-white/90 hover:border-[color:var(--accent-primary)]/50 hover:bg-[color:var(--accent-primary)]/18"
+                ? "border-[color:var(--accent-primary-strong)] bg-[color:var(--accent-primary-strong)]/88 text-[color:var(--accent-primary-contrast)]"
+                : "border-[color:var(--surface-glass-border)]/70 bg-white/75 text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/55 hover:bg-[color:var(--accent-primary)]/18"
             } ${isActiveCity ? "ring-2 ring-[color:var(--accent-secondary)]/70" : ""}`}
             onClick={() => onMarkerSelect?.(point.venue)}
           >
             <div className="flex items-center gap-2">
               <span
                 className={`inline-flex items-center justify-center rounded-full p-1.5 text-[color:var(--accent-primary-contrast)] ${
-                  isLive ? "bg-[color:var(--accent-primary-strong)]" : "bg-[color:var(--accent-secondary-strong)] text-[color:var(--pitch-dark)]"
+                  isLive
+                    ? "bg-[color:var(--accent-primary-strong)]"
+                    : "bg-[color:var(--accent-secondary-strong)] text-[color:var(--pitch-dark)]"
                 }`}
               >
                 ●
               </span>
               <div className="leading-tight">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] opacity-90">{point.venue.city ?? "Unbekannt"}</p>
-                <p className="text-xs font-medium opacity-75">{point.venue.name}</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--text-secondary)]/80">
+                  {point.venue.city ?? "Unbekannt"}
+                </p>
+                <p className="text-xs font-medium text-[color:var(--text-primary)]/85 break-words hyphens-auto">{point.venue.name}</p>
               </div>
             </div>
-            <div className="mt-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.18em] opacity-80">
+            <div className="mt-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-secondary)]/80">
               <span>{isLive ? "Live Slots" : "Auf Anfrage"}</span>
-              <span className="text-white">{isLive ? `${point.venue.pricePerHour} €` : "Kontakt"}</span>
+              <span className="text-[color:var(--accent-primary-strong)]">
+                {isLive ? `${point.venue.pricePerHour} €` : "Kontakt"}
+              </span>
             </div>
           </button>
         );
       })}
 
       {errorMessage ? (
-        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-white/20 bg-black/60 px-4 py-3 text-sm text-white">
+        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--surface-glass-border)]/70 bg-white/85 px-4 py-3 text-sm text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(16,88,60,0.45)]">
           {errorMessage}
         </div>
       ) : null}
@@ -394,10 +400,10 @@ function createMarkerIcon(isLive: boolean, PointCtor?: any) {
   if (!Point) return undefined;
   return {
     path: "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z",
-    fillColor: isLive ? "#1FB864" : "#7C8A82",
-    fillOpacity: 0.95,
-    strokeColor: "#042416",
-    strokeWeight: 1,
+    fillColor: isLive ? "#1FB864" : "#9AB8AF",
+    fillOpacity: 0.92,
+    strokeColor: "#7BD1A5",
+    strokeWeight: 0.8,
     scale: 1.2,
     anchor: new Point(12, 22),
   };
@@ -430,11 +436,15 @@ function createInfoWindowContent(venue: Venue) {
 }
 
 const mapStyles = [
-  { elementType: "geometry", stylers: [{ color: "#0b1f16" }] },
-  { elementType: "labels.text.fill", stylers: [{ color: "#6bf3a5" }] },
-  { elementType: "labels.text.stroke", stylers: [{ color: "#011009" }] },
-  { featureType: "administrative", elementType: "geometry", stylers: [{ visibility: "off" }] },
+  { elementType: "geometry", stylers: [{ color: "#e8f7ef" }] },
+  { elementType: "labels.text.fill", stylers: [{ color: "#1d5c3d" }] },
+  { elementType: "labels.text.stroke", stylers: [{ color: "#f5fffa" }] },
+  { featureType: "administrative", elementType: "geometry", stylers: [{ color: "#c8ebd9" }] },
+  { featureType: "administrative", elementType: "labels.icon", stylers: [{ visibility: "off" }] },
   { featureType: "poi", stylers: [{ visibility: "off" }] },
-  { featureType: "road", stylers: [{ color: "#123525" }] },
-  { featureType: "water", stylers: [{ color: "#05261a" }] },
+  { featureType: "road", elementType: "geometry", stylers: [{ color: "#ffffff" }] },
+  { featureType: "road", elementType: "labels.text.fill", stylers: [{ color: "#9ab8af" }] },
+  { featureType: "road", elementType: "labels.icon", stylers: [{ visibility: "off" }] },
+  { featureType: "transit", stylers: [{ visibility: "off" }] },
+  { featureType: "water", stylers: [{ color: "#c9f1e4" }] },
 ];

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -109,6 +109,22 @@ export function FilterIcon({ className, ...props }: IconProps) {
   );
 }
 
+export function ChevronDownIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeWidth={1.8}
+      stroke="currentColor"
+      className={className}
+      aria-hidden
+      {...props}
+    >
+      <path d="m6.5 9.5 5.5 5 5.5-5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function WifiIcon({ className, ...props }: IconProps) {
   return (
     <svg

--- a/components/sticky-cta.tsx
+++ b/components/sticky-cta.tsx
@@ -1,22 +1,49 @@
 "use client";
 
+import { useState } from "react";
+import { ChevronDownIcon, FilterIcon, SparkleIcon } from "@/components/icons";
+
 export function StickyCta() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
-      <div className="pointer-events-auto inline-flex flex-wrap items-center justify-center gap-3 rounded-full border border-[color:var(--surface-glass-border)]/70 bg-[color:var(--surface-card)]/95 px-4 py-3 text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(4,36,20,0.85)] backdrop-blur">
-        <a
-          href="#hallen"
-          className="theme-transition inline-flex items-center justify-center gap-2 rounded-full bg-[linear-gradient(120deg,rgba(0,108,56,1),rgba(31,184,100,0.92))] px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--accent-primary-contrast)] shadow-[0_18px_48px_-28px_rgba(0,108,56,0.65)] hover:brightness-[1.08] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
-        >
-          Jetzt buchen
-        </a>
-        <a
-          href="mailto:team@sportshub.app"
-          className="theme-transition inline-flex items-center justify-center gap-2 rounded-full border border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card-muted)]/85 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
-        >
-          Demo anfragen
-        </a>
-      </div>
+    <div className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
+      {isOpen ? (
+        <div className="w-full max-w-[260px] rounded-3xl border border-[color:var(--surface-glass-border)]/65 bg-[linear-gradient(135deg,rgba(255,255,255,0.72),rgba(186,234,213,0.75))] p-4 text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(12,74,48,0.45)] backdrop-blur-xl">
+          <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--text-tertiary)]">
+            <SparkleIcon className="h-3.5 w-3.5" />
+            Quick Actions
+          </p>
+          <p className="mt-2 text-sm text-[color:var(--text-secondary)]/85 break-words hyphens-auto">
+            Wähle einen Einstieg: direkt zu den Hallen oder eine persönliche Demo sichern.
+          </p>
+          <div className="mt-3 grid gap-2">
+            <a
+              href="#hallen"
+              className="theme-transition inline-flex items-center justify-center gap-2 rounded-full border border-[color:var(--accent-primary)]/50 bg-[color:var(--accent-primary)]/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--accent-primary-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)] hover:bg-[color:var(--accent-primary)]/22"
+            >
+              Jetzt Hallen ansehen
+            </a>
+            <a
+              href="mailto:team@sportshub.app"
+              className="theme-transition inline-flex items-center justify-center gap-2 rounded-full border border-[color:var(--border-subtle)]/60 bg-[color:var(--surface-card)]/85 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
+            >
+              Demo anfragen
+            </a>
+          </div>
+        </div>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        aria-expanded={isOpen}
+        className="theme-transition inline-flex items-center gap-2 rounded-full border border-[color:var(--surface-glass-border)]/70 bg-[color:var(--surface-card)]/90 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--text-secondary)] shadow-[0_22px_72px_-50px_rgba(12,48,32,0.55)] backdrop-blur hover:border-[color:var(--accent-primary)]/40 hover:text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-secondary)]"
+      >
+        <FilterIcon className="h-4 w-4" />
+        Quick Menu
+        <ChevronDownIcon className={`h-3.5 w-3.5 transition-transform ${isOpen ? "rotate-180" : ""}`} />
+      </button>
     </div>
   );
 }

--- a/components/venue-card.tsx
+++ b/components/venue-card.tsx
@@ -103,10 +103,10 @@ export function VenueCard({ venue }: VenueCardProps) {
             </div>
 
             <div className="space-y-3">
-              <h3 className="text-2xl font-bold leading-tight text-[color:var(--text-primary)] sm:text-[1.7rem]">
+              <h3 className="text-2xl font-bold leading-tight text-[color:var(--text-primary)] break-words hyphens-auto sm:text-[1.7rem]">
                 {venue.name}
               </h3>
-              <p className="text-base leading-relaxed text-[color:var(--text-secondary)]/90">{venue.description}</p>
+              <p className="text-base leading-relaxed text-[color:var(--text-secondary)]/90 break-words hyphens-auto">{venue.description}</p>
             </div>
 
             <div className="flex flex-wrap items-center gap-3 text-sm text-[color:var(--text-secondary)]">
@@ -144,7 +144,7 @@ export function VenueCard({ venue }: VenueCardProps) {
                   )}
                 </p>
                 {venue.notes ? (
-                  <p className="text-sm leading-relaxed text-[color:var(--text-tertiary)]/85">{venue.notes}</p>
+                  <p className="text-sm leading-relaxed text-[color:var(--text-tertiary)]/85 break-words hyphens-auto">{venue.notes}</p>
                 ) : null}
               </div>
             </div>

--- a/components/venue-map.tsx
+++ b/components/venue-map.tsx
@@ -55,7 +55,7 @@ export function VenueMap({ venues, activeCity, onCitySelect }: VenueMapProps) {
   );
 
   return (
-    <div className="glass-panel theme-transition flex h-full flex-col gap-6 rounded-3xl border border-[color:var(--border-subtle)]/70 bg-[color:var(--surface-card)]/78 p-6 text-[color:var(--text-primary)] shadow-[0_45px_160px_-100px_rgba(6,26,18,0.85)]">
+    <div className="glass-panel theme-transition flex h-full flex-col gap-6 rounded-3xl border border-[color:var(--border-subtle)]/65 bg-[linear-gradient(150deg,rgba(255,255,255,0.62),rgba(198,238,216,0.34))] p-6 text-[color:var(--text-primary)] shadow-[0_45px_160px_-100px_rgba(6,26,18,0.7)] backdrop-blur-2xl">
       <header className="space-y-4">
         <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--accent-primary-strong)]">
           <TargetIcon className="h-4 w-4" />
@@ -63,10 +63,10 @@ export function VenueMap({ venues, activeCity, onCitySelect }: VenueMapProps) {
         </div>
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-2">
-            <h3 className="text-2xl font-semibold leading-tight text-[color:var(--text-primary)]">
+            <h3 className="text-2xl font-semibold leading-tight text-[color:var(--text-primary)] break-words hyphens-auto">
               Map View – verfügbare Arenen
             </h3>
-            <p className="max-w-xl text-sm leading-relaxed text-[color:var(--text-secondary)]/85">
+            <p className="max-w-xl text-sm leading-relaxed text-[color:var(--text-secondary)]/85 break-words hyphens-auto">
               Interaktive Pins zeigen dir Preise, Live-Verfügbarkeiten und die schnellsten Buchungswege. Klicke auf einen Marker, um Details zu öffnen und die Ergebnisliste zu fokussieren.
             </p>
           </div>
@@ -93,8 +93,8 @@ export function VenueMap({ venues, activeCity, onCitySelect }: VenueMapProps) {
                   <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--accent-primary-strong)]">
                     {selectedVenue.city ?? "Unbekannter Standort"}
                   </p>
-                  <h4 className="mt-1 text-lg font-semibold leading-tight">{selectedVenue.name}</h4>
-                  <p className="mt-2 text-sm text-[color:var(--text-secondary)]">
+                  <h4 className="mt-1 text-lg font-semibold leading-tight break-words hyphens-auto">{selectedVenue.name}</h4>
+                  <p className="mt-2 text-sm text-[color:var(--text-secondary)] break-words hyphens-auto">
                     {selectedVenue.address ?? "Adresse folgt"}
                   </p>
                 </div>


### PR DESCRIPTION
## Summary
- brighten the live map and fallback styling to match a light glass aesthetic and refresh marker colors
- convert the filter panel into collapsible glass sections with summaries and a subtler floating quick-action menu
- harden text wrapping across hero copy, venue cards, and map details to prevent content overflow

## Testing
- npm run lint *(fails: missing `eslint-plugin-react-hooks` in the lint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc17308ac8332baed1b086c5e6d8e