### PR TITLE
Improve dark mode styling and theme toggle hydration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,28 @@
   --noise-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
   --field-line: #d0f5dd;
   --pitch-dark: #072717;
+  --gradient-hero-shell: linear-gradient(140deg, rgba(255, 255, 255, 0.78), rgba(182, 238, 210, 0.48));
+  --radial-hero-shell: radial-gradient(circle at top right, rgba(92, 255, 157, 0.1), transparent 60%);
+  --gradient-hero-map: linear-gradient(150deg, rgba(6, 32, 20, 0.85), rgba(18, 72, 44, 0.65));
+  --radial-hero-map: radial-gradient(circle at top, rgba(8, 120, 64, 0.22), transparent 70%);
+  --gradient-panel-soft: linear-gradient(150deg, rgba(255, 255, 255, 0.75), rgba(176, 230, 201, 0.45));
+  --radial-panel-soft: radial-gradient(circle at bottom, rgba(92, 255, 157, 0.16), transparent 70%);
+  --gradient-panel-alt: linear-gradient(150deg, rgba(255, 255, 255, 0.78), rgba(164, 226, 195, 0.45));
+  --gradient-filter-card: linear-gradient(145deg, rgba(255, 255, 255, 0.6), rgba(200, 238, 220, 0.38));
+  --gradient-filter-shell: linear-gradient(150deg, rgba(255, 255, 255, 0.58), rgba(198, 239, 219, 0.35));
+  --gradient-sticky-cta: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(186, 234, 213, 0.75));
+  --gradient-filter-sidebar: linear-gradient(150deg, rgba(12, 40, 26, 0.45), rgba(18, 64, 40, 0.35));
+  --gradient-filter-results: linear-gradient(155deg, rgba(255, 255, 255, 0.72), rgba(188, 238, 212, 0.42));
+  --gradient-venue-map: linear-gradient(150deg, rgba(255, 255, 255, 0.62), rgba(198, 238, 216, 0.34));
+  --gradient-map-container: linear-gradient(155deg, rgba(255, 255, 255, 0.82), rgba(204, 239, 222, 0.78));
+  --radial-map-container: radial-gradient(circle at top right, rgba(64, 196, 130, 0.22), transparent 60%);
+  --map-fallback-card-bg: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  --map-fallback-card-border: color-mix(in srgb, var(--surface-glass-border) 68%, transparent);
+  --map-fallback-demo-bg: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  --map-fallback-alert-bg: color-mix(in srgb, var(--surface-card-strong) 82%, transparent);
+  --floating-badge-border: rgba(255, 255, 255, 0.28);
+  --floating-badge-background: rgba(255, 255, 255, 0.18);
+  --floating-badge-text: #ffffff;
   color-scheme: light;
 }
 
@@ -58,6 +80,28 @@
   --noise-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.08'/%3E%3C/svg%3E");
   --field-line: #1f5536;
   --pitch-dark: #02160d;
+  --gradient-hero-shell: linear-gradient(140deg, rgba(12, 34, 24, 0.88), rgba(10, 74, 42, 0.58));
+  --radial-hero-shell: radial-gradient(circle at top right, rgba(64, 196, 130, 0.18), transparent 60%);
+  --gradient-hero-map: linear-gradient(150deg, rgba(2, 20, 12, 0.94), rgba(8, 52, 32, 0.72));
+  --radial-hero-map: radial-gradient(circle at top, rgba(36, 168, 102, 0.18), transparent 70%);
+  --gradient-panel-soft: linear-gradient(150deg, rgba(10, 26, 20, 0.88), rgba(6, 52, 32, 0.52));
+  --radial-panel-soft: radial-gradient(circle at bottom, rgba(56, 186, 112, 0.24), transparent 70%);
+  --gradient-panel-alt: linear-gradient(150deg, rgba(8, 24, 18, 0.9), rgba(4, 44, 26, 0.62));
+  --gradient-filter-card: linear-gradient(145deg, rgba(12, 36, 26, 0.72), rgba(8, 48, 30, 0.5));
+  --gradient-filter-shell: linear-gradient(150deg, rgba(10, 32, 24, 0.72), rgba(6, 48, 30, 0.48));
+  --gradient-sticky-cta: linear-gradient(135deg, rgba(10, 34, 24, 0.82), rgba(14, 54, 34, 0.68));
+  --gradient-filter-sidebar: linear-gradient(150deg, rgba(6, 28, 18, 0.72), rgba(4, 36, 22, 0.55));
+  --gradient-filter-results: linear-gradient(155deg, rgba(10, 30, 22, 0.82), rgba(14, 52, 34, 0.58));
+  --gradient-venue-map: linear-gradient(150deg, rgba(10, 32, 24, 0.78), rgba(8, 48, 30, 0.52));
+  --gradient-map-container: linear-gradient(155deg, rgba(8, 26, 20, 0.92), rgba(6, 40, 28, 0.7));
+  --radial-map-container: radial-gradient(circle at top right, rgba(64, 196, 130, 0.26), transparent 60%);
+  --map-fallback-card-bg: color-mix(in srgb, var(--surface-card) 90%, transparent);
+  --map-fallback-card-border: color-mix(in srgb, var(--surface-glass-border) 78%, transparent);
+  --map-fallback-demo-bg: color-mix(in srgb, var(--surface-card-strong) 82%, transparent);
+  --map-fallback-alert-bg: color-mix(in srgb, var(--surface-card-strong) 86%, transparent);
+  --floating-badge-border: rgba(62, 104, 84, 0.42);
+  --floating-badge-background: rgba(12, 40, 28, 0.58);
+  --floating-badge-text: #ecfff1;
 }
 
 body {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,8 +13,8 @@ export default function HomePage() {
     <div className="space-y-16 lg:space-y-20">
       {/* HERO: left copy, right live map */}
       <section className="container-narrow">
-        <div className="relative overflow-hidden rounded-[2.5rem] border border-[color:var(--border-subtle)]/70 bg-[linear-gradient(140deg,rgba(255,255,255,0.78),rgba(182,238,210,0.48))] px-6 py-10 shadow-[0_46px_160px_-80px_rgba(8,52,28,0.78)] backdrop-blur-[20px] sm:px-10 sm:py-14">
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(92,255,157,0.10),transparent_60%)]" aria-hidden />
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-[color:var(--border-subtle)]/70 bg-[var(--gradient-hero-shell)] px-6 py-10 shadow-[0_46px_160px_-80px_rgba(8,52,28,0.78)] backdrop-blur-[20px] sm:px-10 sm:py-14">
+          <div className="pointer-events-none absolute inset-0 bg-[var(--radial-hero-shell)]" aria-hidden />
           <div className="relative grid gap-10 lg:grid-cols-[minmax(0,1fr),460px] lg:gap-14">
             {/* Left: value + CTA */}
             <div className="space-y-8">
@@ -73,8 +73,8 @@ export default function HomePage() {
 
             {/* Right: live map */}
             <div className="relative">
-              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(8,120,64,0.22),transparent_70%)]" aria-hidden />
-              <div className="relative overflow-hidden rounded-[2rem] border border-[color:var(--surface-glass-border)] bg-[linear-gradient(150deg,rgba(6,32,20,0.85),rgba(18,72,44,0.65))] p-2 shadow-[0_75px_200px_-90px_rgba(2,22,12,0.92)] backdrop-blur-[30px]">
+              <div className="pointer-events-none absolute inset-0 bg-[var(--radial-hero-map)]" aria-hidden />
+              <div className="relative overflow-hidden rounded-[2rem] border border-[color:var(--surface-glass-border)] bg-[var(--gradient-hero-map)] p-2 shadow-[0_75px_200px_-90px_rgba(2,22,12,0.92)] backdrop-blur-[30px]">
                 <div className="h-[360px] rounded-[1.6rem] overflow-hidden">
                   {/* Use your Google map as visual anchor in hero */}
                   <GoogleMapCanvas venues={allVenues} />
@@ -90,8 +90,8 @@ export default function HomePage() {
 
       {/* CATEGORIES / VALUE PROPS */}
       <section className="container-narrow" id="netzwerk">
-        <div className="relative overflow-hidden rounded-[2.25rem] border border-[color:var(--surface-glass-border)] bg-[linear-gradient(150deg,rgba(255,255,255,0.75),rgba(176,230,201,0.45))] px-6 py-11 shadow-[0_60px_170px_-100px_rgba(4,32,18,0.82)] backdrop-blur-[18px] sm:px-10">
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(92,255,157,0.16),transparent_70%)]" aria-hidden />
+        <div className="relative overflow-hidden rounded-[2.25rem] border border-[color:var(--surface-glass-border)] bg-[var(--gradient-panel-soft)] px-6 py-11 shadow-[0_60px_170px_-100px_rgba(4,32,18,0.82)] backdrop-blur-[18px] sm:px-10">
+          <div className="pointer-events-none absolute inset-0 bg-[var(--radial-panel-soft)]" aria-hidden />
           <div className="relative space-y-9">
             <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr),360px] lg:items-start">
               <div className="space-y-4">
@@ -153,7 +153,7 @@ export default function HomePage() {
 
       {/* EXPLAINER / STATS */}
       <section className="container-narrow" id="matchcenter">
-        <div className="relative overflow-hidden rounded-[2.25rem] border border-[color:var(--surface-glass-border)] bg-[linear-gradient(150deg,rgba(255,255,255,0.78),rgba(164,226,195,0.45))] px-6 py-10 shadow-[0_65px_180px_-90px_rgba(6,38,20,0.76)] backdrop-blur-[22px] sm:px-10">
+        <div className="relative overflow-hidden rounded-[2.25rem] border border-[color:var(--surface-glass-border)] bg-[var(--gradient-panel-alt)] px-6 py-10 shadow-[0_65px_180px_-90px_rgba(6,38,20,0.76)] backdrop-blur-[22px] sm:px-10">
           <div className="relative grid gap-8 lg:grid-cols-[minmax(0,1fr),320px]">
             <div className="space-y-8">
               <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr),minmax(0,320px)] sm:items-center">

--- a/components/filter-panel.tsx
+++ b/components/filter-panel.tsx
@@ -148,7 +148,7 @@ function CollapsibleSection({
   return (
     <section
       className={clsx(
-        "theme-transition rounded-2xl border border-[color:var(--surface-glass-border)]/65 bg-[linear-gradient(145deg,rgba(255,255,255,0.6),rgba(200,238,220,0.38))] p-5 shadow-[0_32px_120px_-80px_rgba(12,72,48,0.45)] backdrop-blur-xl",
+        "theme-transition rounded-2xl border border-[color:var(--surface-glass-border)]/65 bg-[var(--gradient-filter-card)] p-5 shadow-[0_32px_120px_-80px_rgba(12,72,48,0.45)] backdrop-blur-xl",
         className
       )}
     >
@@ -402,7 +402,7 @@ export function FilterPanel({
   return (
     <aside
       className={clsx(
-        "glass-panel theme-transition rounded-3xl border border-[color:var(--border-subtle)]/75 bg-[linear-gradient(150deg,rgba(255,255,255,0.58),rgba(198,239,219,0.35))] text-[color:var(--text-primary)] shadow-[0_60px_190px_-110px_rgba(12,72,48,0.55)] backdrop-blur-2xl",
+        "glass-panel theme-transition rounded-3xl border border-[color:var(--border-subtle)]/75 bg-[var(--gradient-filter-shell)] text-[color:var(--text-primary)] shadow-[0_60px_190px_-110px_rgba(12,72,48,0.55)] backdrop-blur-2xl",
         isCompact ? "space-y-5 p-5 lg:p-6" : "space-y-7 p-8",
         className
       )}
@@ -480,7 +480,7 @@ export function FilterPanel({
               value={state.city}
               onChange={(event) => onChange({ ...state, city: event.target.value, nearby: false })}
               className={clsx(
-                "theme-transition w-full rounded-full border border-[color:var(--border-subtle)]/80 bg-white/80 pl-11 pr-4 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
+                "theme-transition w-full rounded-full border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/80 pl-11 pr-4 text-sm font-medium text-[color:var(--text-primary)] placeholder:text-[color:var(--text-secondary)]/70 focus:border-[color:var(--accent-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-secondary)]/40",
                 isCompact ? "py-2.5" : "py-3"
               )}
             />
@@ -524,7 +524,7 @@ export function FilterPanel({
                     isCompact ? "py-1.5" : "py-2",
                     selected
                       ? "border-transparent bg-[color:var(--accent-primary-strong)] text-[color:var(--accent-primary-contrast)] shadow-[0_16px_36px_-22px_rgba(0,108,56,0.55)]"
-                      : "border-[color:var(--surface-glass-border)]/55 bg-white/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary-strong)]/45 hover:text-[color:var(--accent-primary-strong)]"
+                      : "border-[color:var(--surface-glass-border)]/55 bg-[color:var(--surface-card)]/70 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary-strong)]/45 hover:text-[color:var(--accent-primary-strong)]"
                   )}
                 >
                   <span
@@ -552,7 +552,7 @@ export function FilterPanel({
           summary={priceSummary}
         >
           <div className={clsx("grid gap-4", isCompact ? "sm:grid-cols-1" : "sm:grid-cols-2")}> 
-            <div className="rounded-2xl border border-[color:var(--surface-glass-border)]/60 bg-white/80 p-4 shadow-[0_20px_70px_-60px_rgba(12,72,48,0.45)]">
+            <div className="rounded-2xl border border-[color:var(--surface-glass-border)]/60 bg-[color:var(--surface-card)]/80 p-4 shadow-[0_20px_70px_-60px_rgba(12,72,48,0.45)]">
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--text-tertiary)]">
                 Preisrange
               </p>
@@ -603,7 +603,7 @@ export function FilterPanel({
                 Typische Buchungsfenster liegen zwischen 45&nbsp;€ und 70&nbsp;€ pro Stunde.
               </p>
             </div>
-            <div className="rounded-2xl border border-[color:var(--surface-glass-border)]/60 bg-white/80 p-4 shadow-[0_20px_70px_-60px_rgba(12,72,48,0.45)]">
+            <div className="rounded-2xl border border-[color:var(--surface-glass-border)]/60 bg-[color:var(--surface-card)]/80 p-4 shadow-[0_20px_70px_-60px_rgba(12,72,48,0.45)]">
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--text-tertiary)]">
                 Öffnungszeiten
               </p>
@@ -682,7 +682,7 @@ export function FilterPanel({
                           isCompact ? "py-2" : "py-2.5",
                           selected
                             ? "border-[color:var(--accent-primary)]/55 bg-[color:var(--accent-primary)]/14 text-[color:var(--accent-primary)] shadow-[0_14px_32px_-28px_rgba(10,90,60,0.6)]"
-                            : "border-[color:var(--border-subtle)]/60 bg-white/75 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)]"
+                            : "border-[color:var(--border-subtle)]/60 bg-[color:var(--surface-card)]/75 text-[color:var(--text-secondary)] hover:border-[color:var(--accent-primary)]/35 hover:text-[color:var(--accent-primary)]"
                         )}
                       >
                         <span className="inline-flex items-center gap-3">
@@ -710,7 +710,7 @@ export function FilterPanel({
       </div>
       <div
         className={clsx(
-          "rounded-2xl border border-dashed border-[color:var(--border-subtle)]/60 bg-white/80 text-[color:var(--text-secondary)] backdrop-blur",
+          "rounded-2xl border border-dashed border-[color:var(--border-subtle)]/60 bg-[color:var(--surface-card)]/80 text-[color:var(--text-secondary)] backdrop-blur",
           isCompact ? "px-4 py-2 text-[11px]" : "px-4 py-3 text-xs"
         )}
       >

--- a/components/filterable-venue-list.tsx
+++ b/components/filterable-venue-list.tsx
@@ -303,7 +303,7 @@ export function FilterableVenueList({ venues, sports, amenities }: FilterableVen
               />
             </div>
           ) : (
-            <div className="lg:sticky lg:top-24 rounded-3xl border border-[color:var(--surface-glass-border)]/60 bg-[linear-gradient(150deg,rgba(12,40,26,0.45),rgba(18,64,40,0.35))] px-6 py-6 text-[color:var(--text-primary)] shadow-[0_60px_160px_-90px_rgba(6,36,22,0.6)] backdrop-blur-2xl">
+            <div className="lg:sticky lg:top-24 rounded-3xl border border-[color:var(--surface-glass-border)]/60 bg-[var(--gradient-filter-sidebar)] px-6 py-6 text-[color:var(--text-primary)] shadow-[0_60px_160px_-90px_rgba(6,36,22,0.6)] backdrop-blur-2xl">
               <div className="flex flex-wrap items-center justify-between gap-4">
                 <div className="space-y-2">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent-primary)]/85">
@@ -339,7 +339,7 @@ export function FilterableVenueList({ venues, sports, amenities }: FilterableVen
         </div>
 
         <div className="space-y-7">
-          <div className="glass-panel theme-transition space-y-5 rounded-3xl border border-[color:var(--border-subtle)]/70 bg-[linear-gradient(155deg,rgba(255,255,255,0.72),rgba(188,238,212,0.42))] px-6 py-6 text-[color:var(--text-primary)] shadow-[0_48px_160px_-90px_rgba(6,36,22,0.68)] lg:px-8 lg:py-7">
+          <div className="glass-panel theme-transition space-y-5 rounded-3xl border border-[color:var(--border-subtle)]/70 bg-[var(--gradient-filter-results)] px-6 py-6 text-[color:var(--text-primary)] shadow-[0_48px_160px_-90px_rgba(6,36,22,0.68)] lg:px-8 lg:py-7">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
               <div className="space-y-3">
                 <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--accent-primary-strong)]">

--- a/components/google-map-canvas.tsx
+++ b/components/google-map-canvas.tsx
@@ -259,8 +259,8 @@ export function GoogleMapCanvas({
   const shouldRenderFallback = !apiKey || !!scriptError || !isScriptLoaded;
 
   return (
-    <div className="relative h-full min-h-[420px] overflow-hidden rounded-3xl border border-[color:var(--surface-glass-border)]/70 bg-[linear-gradient(155deg,rgba(255,255,255,0.82),rgba(204,239,222,0.78))] shadow-[0_45px_160px_-100px_rgba(12,78,48,0.55)]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(64,196,130,0.22),transparent_60%)]" aria-hidden />
+    <div className="relative h-full min-h-[420px] overflow-hidden rounded-3xl border border-[color:var(--surface-glass-border)]/70 bg-[var(--gradient-map-container)] shadow-[0_45px_160px_-100px_rgba(12,78,48,0.55)]">
+      <div className="pointer-events-none absolute inset-0 bg-[var(--radial-map-container)]" aria-hidden />
       {shouldRenderFallback ? (
         <FallbackMap
           points={venuePoints}
@@ -273,12 +273,12 @@ export function GoogleMapCanvas({
         <div ref={containerRef} className="absolute inset-0" role="presentation" />
       )}
       {!apiKey && (
-        <div className="pointer-events-none absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--accent-primary-strong)] shadow-[0_12px_32px_-20px_rgba(12,74,48,0.45)]">
+        <div className="pointer-events-none absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-[color:var(--map-fallback-demo-bg)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--accent-primary-strong)] shadow-[0_12px_32px_-20px_rgba(12,74,48,0.45)]">
           Demo-Modus ohne API-Key
         </div>
       )}
       {scriptError ? (
-        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--accent-secondary)]/40 bg-white/80 px-4 py-3 text-sm text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(12,78,48,0.45)]">
+        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--accent-secondary)]/40 bg-[color:var(--map-fallback-alert-bg)] px-4 py-3 text-sm text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(12,78,48,0.45)]">
           {scriptError}
         </div>
       ) : null}
@@ -335,7 +335,7 @@ function FallbackMap({ points, activeCity, selectedVenueId, onMarkerSelect, erro
             className={`theme-transition absolute -translate-x-1/2 -translate-y-full rounded-2xl border px-4 py-3 text-left shadow-[0_26px_70px_-42px_rgba(16,88,60,0.55)] backdrop-blur ${
               isSelected
                 ? "border-[color:var(--accent-primary-strong)] bg-[color:var(--accent-primary-strong)]/88 text-[color:var(--accent-primary-contrast)]"
-                : "border-[color:var(--surface-glass-border)]/70 bg-white/75 text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/55 hover:bg-[color:var(--accent-primary)]/18"
+                : "border-[color:var(--map-fallback-card-border)] bg-[color:var(--map-fallback-card-bg)] text-[color:var(--text-primary)] hover:border-[color:var(--accent-primary)]/55 hover:bg-[color:var(--accent-primary)]/18"
             } ${isActiveCity ? "ring-2 ring-[color:var(--accent-secondary)]/70" : ""}`}
             onClick={() => onMarkerSelect?.(point.venue)}
           >
@@ -367,7 +367,7 @@ function FallbackMap({ points, activeCity, selectedVenueId, onMarkerSelect, erro
       })}
 
       {errorMessage ? (
-        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--surface-glass-border)]/70 bg-white/85 px-4 py-3 text-sm text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(16,88,60,0.45)]">
+        <div className="absolute inset-x-4 bottom-4 rounded-2xl border border-[color:var(--surface-glass-border)]/70 bg-[color:var(--map-fallback-alert-bg)] px-4 py-3 text-sm text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(16,88,60,0.45)]">
           {errorMessage}
         </div>
       ) : null}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -10,6 +10,7 @@ export function SiteHeader() {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const isDarkTheme = theme === "dark";
+  const [isMounted, setIsMounted] = useState(false);
 
   const toggleLabel = useMemo(
     () => (isDarkTheme ? "Zum hellen Modus wechseln" : "Zum dunklen Modus wechseln"),
@@ -17,6 +18,12 @@ export function SiteHeader() {
   );
 
   const toggleText = useMemo(() => (isDarkTheme ? "Dunkel" : "Hell"), [isDarkTheme]);
+  const displayedToggleText = isMounted ? toggleText : "Modus";
+  const displayedIcon = isMounted ? (isDarkTheme ? "🌙" : "🌞") : "🌗";
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -82,9 +89,9 @@ export function SiteHeader() {
             className="theme-transition inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/70 px-3 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background-primary)]"
           >
             <span aria-hidden className="text-base leading-none">
-              {isDarkTheme ? "🌙" : "🌞"}
+              {displayedIcon}
             </span>
-            <span>{toggleText}</span>
+            <span>{displayedToggleText}</span>
           </button>
           <div className="hidden items-center gap-2 rounded-full border border-[color:var(--border-subtle)]/80 bg-[color:var(--surface-card)]/70 px-4 py-2 text-[color:var(--text-secondary)] sm:flex">
             <span className="text-xs font-semibold uppercase tracking-[0.28em]">Live</span>
@@ -160,9 +167,9 @@ export function SiteHeader() {
               className="theme-transition inline-flex w-full items-center justify-center gap-2 rounded-full border border-[color:var(--border-subtle)] px-4 py-2 font-semibold text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background-primary)]"
             >
               <span aria-hidden className="text-base leading-none">
-                {isDarkTheme ? "🌙" : "🌞"}
+                {displayedIcon}
               </span>
-              <span>{toggleText}-Modus</span>
+              <span>{isMounted ? `${toggleText}-Modus` : "Modus"}</span>
             </button>
           </li>
         </ul>

--- a/components/sticky-cta.tsx
+++ b/components/sticky-cta.tsx
@@ -9,7 +9,7 @@ export function StickyCta() {
   return (
     <div className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
       {isOpen ? (
-        <div className="w-full max-w-[260px] rounded-3xl border border-[color:var(--surface-glass-border)]/65 bg-[linear-gradient(135deg,rgba(255,255,255,0.72),rgba(186,234,213,0.75))] p-4 text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(12,74,48,0.45)] backdrop-blur-xl">
+    <div className="w-full max-w-[260px] rounded-3xl border border-[color:var(--surface-glass-border)]/65 bg-[var(--gradient-sticky-cta)] p-4 text-[color:var(--text-primary)] shadow-[0_32px_120px_-60px_rgba(12,74,48,0.45)] backdrop-blur-xl">
           <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--text-tertiary)]">
             <SparkleIcon className="h-3.5 w-3.5" />
             Quick Actions

--- a/components/venue-card.tsx
+++ b/components/venue-card.tsx
@@ -70,7 +70,7 @@ export function VenueCard({ venue }: VenueCardProps) {
           priority={false}
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/25 to-transparent" aria-hidden />
-        <div className="absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/15 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-white shadow-[0_14px_45px_-30px_rgba(0,0,0,0.75)] backdrop-blur">
+        <div className="absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-[color:var(--floating-badge-border)] bg-[color:var(--floating-badge-background)] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--floating-badge-text)] shadow-[0_14px_45px_-30px_rgba(0,0,0,0.75)] backdrop-blur">
           <BadgeCheckIcon className="h-4 w-4" />
           Verifiziert
         </div>

--- a/components/venue-detail.tsx
+++ b/components/venue-detail.tsx
@@ -49,7 +49,7 @@ export function VenueDetail({ venue }: VenueDetailProps) {
             priority
           />
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/35 to-transparent" aria-hidden />
-          <div className="pointer-events-none absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-white/35 bg-black/35 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-[0_18px_42px_-24px_rgba(0,0,0,0.8)] backdrop-blur" aria-hidden>
+        <div className="pointer-events-none absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-[color:var(--floating-badge-border)] bg-[color:var(--floating-badge-background)] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--floating-badge-text)] shadow-[0_18px_42px_-24px_rgba(0,0,0,0.8)] backdrop-blur" aria-hidden>
             Arena Highlight
           </div>
           <div className="absolute bottom-6 left-6 right-6 flex flex-wrap items-center gap-3 rounded-2xl bg-black/30 px-5 py-3 text-sm text-white backdrop-blur">

--- a/components/venue-map.tsx
+++ b/components/venue-map.tsx
@@ -55,7 +55,7 @@ export function VenueMap({ venues, activeCity, onCitySelect }: VenueMapProps) {
   );
 
   return (
-    <div className="glass-panel theme-transition flex h-full flex-col gap-6 rounded-3xl border border-[color:var(--border-subtle)]/65 bg-[linear-gradient(150deg,rgba(255,255,255,0.62),rgba(198,238,216,0.34))] p-6 text-[color:var(--text-primary)] shadow-[0_45px_160px_-100px_rgba(6,26,18,0.7)] backdrop-blur-2xl">
+    <div className="glass-panel theme-transition flex h-full flex-col gap-6 rounded-3xl border border-[color:var(--border-subtle)]/65 bg-[var(--gradient-venue-map)] p-6 text-[color:var(--text-primary)] shadow-[0_45px_160px_-100px_rgba(6,26,18,0.7)] backdrop-blur-2xl">
       <header className="space-y-4">
         <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--accent-primary-strong)]">
           <TargetIcon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- add theme-specific gradient tokens and reuse them across hero, map and listing panels for consistent light and dark themes
- resolve the theme toggle hydration mismatch by deferring icon/text rendering until the client is mounted
- refresh map, filter, CTA and venue badges to rely on theme-aware surfaces and alerts so dark mode visuals stay balanced

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcc7f1fa48332b4a593a7e28b4c97