### PR TITLE
Refine glass card padding for iOS app

### DIFF
--- a/ios/src/components/GlassCard.tsx
+++ b/ios/src/components/GlassCard.tsx
@@ -7,10 +7,11 @@ import { useTheme } from '../theme/ThemeProvider';
 interface GlassCardProps {
   children: ReactNode;
   style?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<ViewStyle>;
   intensity?: number;
 }
 
-export const GlassCard = ({ children, style, intensity = 50 }: GlassCardProps) => {
+export const GlassCard = ({ children, style, contentStyle, intensity = 50 }: GlassCardProps) => {
   const { colors } = useTheme();
 
   return (
@@ -20,7 +21,7 @@ export const GlassCard = ({ children, style, intensity = 50 }: GlassCardProps) =
           colors={[colors.surface, 'rgba(94,157,255,0.08)']}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
-          style={styles.gradient}
+          style={[styles.gradient, contentStyle]}
         >
           {children}
         </LinearGradient>

--- a/ios/src/screens/FavoritesScreen.tsx
+++ b/ios/src/screens/FavoritesScreen.tsx
@@ -11,7 +11,7 @@ export const FavoritesScreen = () => {
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
       <View style={styles.container}>
         <Text style={[typography.headingL, styles.title]}>Favorites</Text>
-        <GlassCard style={styles.card}>
+        <GlassCard contentStyle={styles.cardContent}>
           <Text style={[typography.caption, styles.copy]}>
             Save your go-to pitches here. Booked venues will surface with upcoming reservations,
             loyalty perks, and instant re-booking actions.
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
     color: 'white',
     marginBottom: 20
   },
-  card: {
+  cardContent: {
     padding: 20
   },
   copy: {

--- a/ios/src/screens/FiltersScreen.tsx
+++ b/ios/src/screens/FiltersScreen.tsx
@@ -11,7 +11,7 @@ export const FiltersScreen = () => {
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.container} showsVerticalScrollIndicator={false}>
         <Text style={[typography.headingL, styles.title]}>Filters</Text>
-        <GlassCard style={styles.card}>
+        <GlassCard contentStyle={styles.cardContent}>
           <Text style={[typography.caption, styles.copy]}>
             Use the upcoming iterations of this screen to configure complex filters, including price
             sliders, facility features, and advanced scheduling with bottom-sheet interactions.
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
     color: 'white',
     marginBottom: 20
   },
-  card: {
+  cardContent: {
     padding: 20
   },
   copy: {

--- a/ios/src/screens/HomeScreen.tsx
+++ b/ios/src/screens/HomeScreen.tsx
@@ -60,7 +60,7 @@ export const HomeScreen = ({ navigation }: Props) => {
 
         <MapPreview>
           <View style={styles.mapOverlay}>
-            <GlassCard style={styles.mapCallout} intensity={80}>
+            <GlassCard contentStyle={styles.mapCalloutContent} intensity={80}>
               <Text style={[typography.headingM, styles.calloutTitle]}>Liquid Glass Pavilion</Text>
               <View style={styles.calloutMeta}>
                 <Ionicons name="navigate" size={16} color={colors.aqua} />
@@ -155,7 +155,7 @@ const styles = StyleSheet.create({
     left: 24,
     right: 24
   },
-  mapCallout: {
+  mapCalloutContent: {
     padding: 18
   },
   calloutTitle: {

--- a/ios/src/screens/ProfileScreen.tsx
+++ b/ios/src/screens/ProfileScreen.tsx
@@ -22,7 +22,7 @@ export const ProfileScreen = () => {
             <Text style={[typography.caption, styles.subtitle]}>Club captain • Skyline Fives</Text>
           </View>
         </View>
-        <GlassCard style={styles.card}>
+        <GlassCard contentStyle={styles.cardContent}>
           <Text style={[typography.caption, styles.copy]}>
             Manage account, payment methods, and your upcoming fixtures. Future updates will connect to
             Apple Wallet passes, Live Activities, and shareable match highlights.
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.75)',
     marginTop: 6
   },
-  card: {
+  cardContent: {
     padding: 20
   },
   copy: {

--- a/ios/src/screens/VenueDetailScreen.tsx
+++ b/ios/src/screens/VenueDetailScreen.tsx
@@ -65,7 +65,7 @@ export const VenueDetailScreen = ({ navigation }: Props) => {
         contentContainerStyle={{ paddingBottom: 120 }}
         showsVerticalScrollIndicator={false}
       >
-        <GlassCard style={styles.infoCard}>
+        <GlassCard style={styles.infoCard} contentStyle={styles.infoCardContent}>
           <View style={styles.infoHeader}>
             <View>
               <Text style={[typography.headingL, styles.infoTitle]}>${venue.hourlyRate}/hr</Text>
@@ -103,7 +103,7 @@ export const VenueDetailScreen = ({ navigation }: Props) => {
 
         <View style={styles.section}>
           <Text style={[typography.headingM, styles.sectionTitle]}>Location</Text>
-          <GlassCard style={styles.mapCard}>
+          <GlassCard contentStyle={styles.mapCardContent}>
             <View style={styles.mapRow}>
               <Ionicons name="navigate" size={20} color={colors.aqua} />
               <Text style={[typography.caption, styles.mapLabel]}>
@@ -181,8 +181,10 @@ const styles = StyleSheet.create({
     marginTop: -32
   },
   infoCard: {
-    padding: 20,
     marginBottom: 24
+  },
+  infoCardContent: {
+    padding: 20
   },
   infoHeader: {
     flexDirection: 'row',
@@ -237,7 +239,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap'
   },
-  mapCard: {
+  mapCardContent: {
     padding: 20
   },
   mapRow: {


### PR DESCRIPTION
## Summary
- add a `contentStyle` override to the GlassCard component so inner padding can be tuned per usage
- update the iOS screens to apply padding through the new prop to keep the liquid glass layout consistent

## Testing
- npm install *(fails: 403 Forbidden when reaching the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe082c79883329b4080325128e606