### PR TITLE
Fix Expo iOS dependency versions

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -12,20 +12,42 @@ This directory contains a fully wired Expo React Native application that impleme
 
 ## Getting started
 
-1. Install dependencies (requires Node.js 18+):
+1. **Install prerequisites**
+   - Node.js 18 or newer (use `nvm install 18 && nvm use 18` if required).
+   - Xcode with the iOS Simulator component.
+   - Expo CLI (no global install required, we will use `npx`).
+
+2. **Install dependencies**
 
    ```bash
    cd ios
    npm install
    ```
 
-2. Launch the Expo development server:
+   If you previously installed packages before this update, clear caches first:
+
+   ```bash
+   rm -rf node_modules package-lock.json
+   npm install
+   ```
+
+3. **Start the development server**
 
    ```bash
    npm run start
    ```
 
-3. Press `i` to open the iOS simulator or scan the QR code with the Expo Go app on an iPhone.
+4. **Open the app**
+   - Press `i` in the Expo CLI terminal to launch the iOS simulator, or
+   - Scan the QR code with the Expo Go app on a physical iPhone (both devices must be on the same network).
+
+5. **(Optional) Run a full native build**
+
+   ```bash
+   npm run ios
+   ```
+
+   This will create a local development build using Xcode and open it in the simulator.
 
 ## Project structure
 

--- a/ios/package.json
+++ b/ios/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "expo": "^54.0.12",
-    "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react": "18.3.1",
+    "react-native": "0.76.3",
 
     "@expo/vector-icons": "^14.0.2",
     "expo-blur": "~14.0.0",
@@ -32,8 +32,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",
-    "@types/react": "19.1.5",
-    "@types/react-native": "0.76.0",
+    "@types/react": "^18.2.45",
     "eslint": "^8.57.0",
     "eslint-config-universe": "^13.0.1",
     "typescript": "^5.4.0"


### PR DESCRIPTION
## Summary
- align the Expo app's React and React Native versions with the Expo SDK
- drop the unavailable @types/react-native package and use matching React type definitions
- expand the iOS README with clearer environment setup and run instructions

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe40921c88332b66ec80aa333736b