### PR TITLE
Fix React Navigation dependency versions for Expo iOS app

### DIFF
--- a/ios/package.json
+++ b/ios/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "@react-navigation/bottom-tabs": "^7.4.7",
-    "@react-navigation/native": "^7.0.0",
-    "@react-navigation/native-stack": "^7.0.0",
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "@react-navigation/native": "^6.1.17",
+    "@react-navigation/native-stack": "^6.9.23",
     "babel-plugin-module-resolver": "^5.0.2",
     "expo": "~51.0.24",
     "expo-blur": "~13.0.2",


### PR DESCRIPTION
## Summary
- align the iOS Expo project's React Navigation packages with the stable 6.x line to match Expo SDK 51
- avoid pulling the newer 7.x releases that can break the iOS simulator launch

## Testing
- not run (network-restricted environment prevents installing npm packages)


------
https://chatgpt.com/codex/tasks/task_e_68dfee2006f883329cc707e8c4e42dd1