### PR TITLE
Fix dependency peer resolution for web and iOS packages

### DIFF
--- a/ios/package.json
+++ b/ios/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint --ext .ts,.tsx src"
   },
   "dependencies": {
+    "@babel/core": "7.25.0",
     "@expo/vector-icons": "14.0.2",
     "@react-navigation/native": "6.1.17",
     "@react-navigation/bottom-tabs": "6.5.20",
@@ -28,7 +29,6 @@
     "react-native-screens": "~3.31.1"
   },
   "devDependencies": {
-    "@babel/core": "7.25.0",
     "@types/react": "18.2.45",
     "babel-plugin-module-resolver": "5.0.2",
     "eslint": "8.57.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "globals": "13.24.0",
     "postcss": "8.5.6",
     "tailwindcss": "3.4.17",
-    "typescript": "5.4.0",
-    "typescript-eslint": "8.38.0"
+    "typescript": "5.8.2",
+    "typescript-eslint": "8.45.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin the TypeScript toolchain to versions that satisfy the typescript-eslint peer range
- promote @babel/core to an app dependency for the Expo project so react-native-reanimated sees its peer during install

## Testing
- not run (npm registry access is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e012404c8c8332bee9dec9c6a05bf6