### PR TITLE
fix missing babel preset dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postcss": "8.5.6",
     "tailwindcss": "3.4.17",
     "typescript": "5.8.2",
-    "typescript-eslint": "8.45.0"
+    "typescript-eslint": "8.45.0",
+    "babel-preset-expo": "10.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- add the `babel-preset-expo` dev dependency so Expo bundler can resolve the preset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e110b3cdd88332aa2b76047cea936c