### PR TITLE
Add native map tab and advanced filters to iOS app

### DIFF
--- a/ios/App.tsx
+++ b/ios/App.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { RootNavigator } from './src/navigation/RootNavigator';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
+import { FiltersProvider } from './src/context/FiltersContext';
 
 const ThemedNavigation = () => {
   const { navigationTheme } = useTheme();
@@ -21,7 +22,9 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <ThemedNavigation />
+        <FiltersProvider>
+          <ThemedNavigation />
+        </FiltersProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/ios/package.json
+++ b/ios/package.json
@@ -22,6 +22,7 @@
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",
     "react-native": "0.81.4",
+    "react-native-maps": "1.11.2",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "4.1.2",
     "react-native-safe-area-context": "~5.6.0",

--- a/ios/src/context/FiltersContext.tsx
+++ b/ios/src/context/FiltersContext.tsx
@@ -1,0 +1,88 @@
+import React, { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+export type Weekday =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+export type FilterState = {
+  sports: string[];
+  city: string;
+  nearby: boolean;
+  priceMin?: number;
+  priceMax?: number;
+  day?: Weekday | '';
+  amenities: string[];
+};
+
+interface FiltersContextValue {
+  filters: FilterState;
+  setFilters: (next: FilterState | ((previous: FilterState) => FilterState)) => void;
+  updateFilters: (partial: Partial<FilterState>) => void;
+  resetFilters: () => void;
+}
+
+const DEFAULT_STATE: FilterState = {
+  sports: [],
+  city: '',
+  nearby: false,
+  priceMin: undefined,
+  priceMax: undefined,
+  day: '',
+  amenities: []
+};
+
+const FiltersContext = createContext<FiltersContextValue | undefined>(undefined);
+
+export const FiltersProvider = ({ children }: { children: ReactNode }) => {
+  const [filters, setFiltersState] = useState<FilterState>(DEFAULT_STATE);
+
+  const setFilters = useCallback(
+    (next: FilterState | ((previous: FilterState) => FilterState)) => {
+      setFiltersState((previous) => (typeof next === 'function' ? (next as (value: FilterState) => FilterState)(previous) : next));
+    },
+    []
+  );
+
+  const updateFilters = useCallback((partial: Partial<FilterState>) => {
+    setFiltersState((previous) => ({ ...previous, ...partial }));
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    setFiltersState(DEFAULT_STATE);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      filters,
+      setFilters,
+      updateFilters,
+      resetFilters
+    }),
+    [filters, resetFilters, setFilters, updateFilters]
+  );
+
+  return <FiltersContext.Provider value={value}>{children}</FiltersContext.Provider>;
+};
+
+export const useFilters = () => {
+  const context = useContext(FiltersContext);
+  if (!context) {
+    throw new Error('useFilters must be used within FiltersProvider');
+  }
+  return context;
+};
+
+export const weekdayLabels: Record<Weekday, string> = {
+  monday: 'Montag',
+  tuesday: 'Dienstag',
+  wednesday: 'Mittwoch',
+  thursday: 'Donnerstag',
+  friday: 'Freitag',
+  saturday: 'Samstag',
+  sunday: 'Sonntag'
+};

--- a/ios/src/data/cityCoordinates.ts
+++ b/ios/src/data/cityCoordinates.ts
@@ -1,0 +1,40 @@
+export interface CityCoordinate {
+  lat: number;
+  lng: number;
+  label: string;
+}
+
+export const CITY_COORDINATES: Record<string, CityCoordinate> = {
+  'Bad Homburg': { lat: 50.226, lng: 8.6182, label: 'Bad Homburg' },
+  Bischofsheim: { lat: 49.9854, lng: 8.3699, label: 'Bischofsheim' },
+  Bretten: { lat: 49.0383, lng: 8.7043, label: 'Bretten' },
+  Bruchsal: { lat: 49.1241, lng: 8.5981, label: 'Bruchsal' },
+  'Brühl (Baden)': { lat: 49.3927, lng: 8.533, label: 'Brühl (Baden)' },
+  Darmstadt: { lat: 49.8728, lng: 8.6512, label: 'Darmstadt' },
+  Dudenhofen: { lat: 49.3192, lng: 8.4206, label: 'Dudenhofen' },
+  Frankfurt: { lat: 50.1109, lng: 8.6821, label: 'Frankfurt' },
+  'Frankfurt am Main': { lat: 50.1109, lng: 8.6821, label: 'Frankfurt am Main' },
+  'Freiburg im Breisgau': { lat: 47.999, lng: 7.8421, label: 'Freiburg im Breisgau' },
+  Heidelberg: { lat: 49.3988, lng: 8.6724, label: 'Heidelberg' },
+  Karlsruhe: { lat: 49.0069, lng: 8.4037, label: 'Karlsruhe' },
+  Kuppenheim: { lat: 48.8211, lng: 8.2525, label: 'Kuppenheim' },
+  Langen: { lat: 49.9896, lng: 8.6734, label: 'Langen' },
+  Ludwigshafen: { lat: 49.4811, lng: 8.4353, label: 'Ludwigshafen' },
+  'Ludwigshafen am Rhein': { lat: 49.4811, lng: 8.4353, label: 'Ludwigshafen am Rhein' },
+  Mannheim: { lat: 49.4875, lng: 8.466, label: 'Mannheim' },
+  Mainaschaff: { lat: 49.9809, lng: 9.0833, label: 'Mainaschaff' },
+  Mainz: { lat: 49.9929, lng: 8.2473, label: 'Mainz' },
+  'Neu-Isenburg': { lat: 50.0483, lng: 8.6941, label: 'Neu-Isenburg' },
+  'Nußloch': { lat: 49.3236, lng: 8.6978, label: 'Nußloch' },
+  'Offenbach am Main': { lat: 50.0956, lng: 8.7761, label: 'Offenbach am Main' },
+  Sindelfingen: { lat: 48.7089, lng: 9.0022, label: 'Sindelfingen' },
+  Walldorf: { lat: 49.3064, lng: 8.6414, label: 'Walldorf' },
+  Wiesbaden: { lat: 50.0782, lng: 8.2398, label: 'Wiesbaden' }
+};
+
+export const DEFAULT_REGION = {
+  latitude: 50.0,
+  longitude: 8.5,
+  latitudeDelta: 4.5,
+  longitudeDelta: 4.5
+};

--- a/ios/src/navigation/RootNavigator.tsx
+++ b/ios/src/navigation/RootNavigator.tsx
@@ -9,9 +9,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeProvider';
 import { HomeScreen } from '../screens/HomeScreen';
 import { VenueDetailScreen } from '../screens/VenueDetailScreen';
-import { FiltersScreen } from '../screens/FiltersScreen';
 import { ProfileScreen } from '../screens/ProfileScreen';
 import { FavoritesScreen } from '../screens/FavoritesScreen';
+import { MapScreen } from '../screens/MapScreen';
+import { FiltersScreen } from '../screens/FiltersScreen';
 import { RootStackParamList, TabParamList } from '../types/navigation';
 
 const Tab = createBottomTabNavigator<TabParamList>();
@@ -20,7 +21,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 const TAB_ICONS: Record<keyof TabParamList, keyof typeof Ionicons.glyphMap> = {
   Home: 'home-outline',
   Favorites: 'heart-outline',
-  Filters: 'options-outline',
+  Map: 'map-outline',
   Profile: 'person-outline'
 };
 
@@ -92,7 +93,7 @@ const Tabs = () => {
     >
       <Tab.Screen name="Home" component={HomeScreen} />
       <Tab.Screen name="Favorites" component={FavoritesScreen} />
-      <Tab.Screen name="Filters" component={FiltersScreen} />
+      <Tab.Screen name="Map" component={MapScreen} />
       <Tab.Screen name="Profile" component={ProfileScreen} />
     </Tab.Navigator>
   );
@@ -109,6 +110,7 @@ export const RootNavigator = () => {
       }}
     >
       <Stack.Screen name="Tabs" component={Tabs} />
+      <Stack.Screen name="Filters" component={FiltersScreen} />
       <Stack.Screen name="VenueDetail" component={VenueDetailScreen} />
     </Stack.Navigator>
   );

--- a/ios/src/screens/FiltersScreen.tsx
+++ b/ios/src/screens/FiltersScreen.tsx
@@ -1,22 +1,237 @@
-import React from 'react';
-import { ScrollView, StyleSheet, Text } from 'react-native';
+import React, { useMemo } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import { GlassCard } from '../components/GlassCard';
 import { useTheme } from '../theme/ThemeProvider';
+import { useFilters, weekdayLabels } from '../context/FiltersContext';
+import { venues } from '../data/venues';
+import { filterVenues, weekdayOrder } from '../utils/filtering';
+import { VenueCard } from '../components/VenueCard';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types/navigation';
 
-export const FiltersScreen = () => {
-  const { typography } = useTheme();
+interface Props {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Filters'>;
+}
+
+const getUniqueValues = (items: string[]): string[] => Array.from(new Set(items)).sort((a, b) => a.localeCompare(b));
+
+export const FiltersScreen = ({ navigation }: Props) => {
+  const { typography, colors } = useTheme();
+  const { filters, updateFilters, resetFilters } = useFilters();
+
+  const sportOptions = useMemo(() => getUniqueValues(venues.flatMap((venue) => venue.sports)), []);
+  const amenityOptions = useMemo(() => getUniqueValues(venues.flatMap((venue) => venue.amenities)), []);
+
+  const filteredVenues = useMemo(() => filterVenues(venues, filters), [filters]);
+
+  const toggleValue = (value: string, current: string[], onChange: (next: string[]) => void) => {
+    const exists = current.includes(value);
+    const next = exists ? current.filter((item) => item !== value) : [...current, value];
+    onChange(next);
+  };
+
+  const handleSportToggle = (sport: string) => toggleValue(sport, filters.sports, (next) => updateFilters({ sports: next }));
+  const handleAmenityToggle = (amenity: string) =>
+    toggleValue(amenity, filters.amenities, (next) => updateFilters({ amenities: next }));
+
+  const handlePriceChange = (value: string, key: 'priceMin' | 'priceMax') => {
+    const numeric = value.trim() === '' ? undefined : Number.parseInt(value, 10);
+    updateFilters({ [key]: Number.isNaN(numeric) ? undefined : numeric });
+  };
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
-      <ScrollView contentContainerStyle={styles.container} showsVerticalScrollIndicator={false}>
-        <Text style={[typography.headingL, styles.title]}>Filters</Text>
-        <GlassCard contentStyle={styles.cardContent}>
-          <Text style={[typography.caption, styles.copy]}>
-            Use the upcoming iterations of this screen to configure complex filters, including price
-            sliders, facility features, and advanced scheduling with bottom-sheet interactions.
-          </Text>
+      <ScrollView
+        contentContainerStyle={styles.container}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.headerRow}>
+          <View>
+            <Text style={[typography.caption, styles.caption]}>Filter konfigurieren</Text>
+            <Text style={[typography.headingXL, styles.title]}>Feinjustierung</Text>
+          </View>
+          <TouchableOpacity style={styles.resetButton} onPress={resetFilters} accessibilityRole="button">
+            <Ionicons name="refresh" size={18} color={colors.aqua} />
+            <Text style={[typography.caption, styles.resetLabel]}>Zurücksetzen</Text>
+          </TouchableOpacity>
+        </View>
+
+        <GlassCard>
+          <View style={styles.sectionHeader}>
+            <Text style={[typography.headingM, styles.sectionTitle]}>Standort</Text>
+            <Text style={[typography.caption, styles.sectionDescription]}>
+              Suche nach Städten oder Stadtteilen in unserem Netzwerk.
+            </Text>
+          </View>
+          <View style={styles.inputWrapper}>
+            <Ionicons name="search" size={18} color={colors.aqua} />
+            <TextInput
+              style={[typography.caption, styles.input]}
+              placeholder="Stadt suchen"
+              placeholderTextColor="rgba(255,255,255,0.45)"
+              value={filters.city}
+              onChangeText={(value) => updateFilters({ city: value })}
+            />
+          </View>
         </GlassCard>
+
+        <GlassCard>
+          <View style={styles.sectionHeader}>
+            <Text style={[typography.headingM, styles.sectionTitle]}>Sportarten</Text>
+            <Text style={[typography.caption, styles.sectionDescription]}>
+              Wähle eine oder mehrere Disziplinen aus.
+            </Text>
+          </View>
+          <View style={styles.chipGrid}>
+            {sportOptions.map((sport) => {
+              const active = filters.sports.includes(sport);
+              return (
+                <TouchableOpacity
+                  key={sport}
+                  style={[styles.chip, active && styles.chipActive]}
+                  onPress={() => handleSportToggle(sport)}
+                  accessibilityRole="button"
+                >
+                  <Ionicons
+                    name={active ? 'checkmark-circle' : 'ellipse-outline'}
+                    size={16}
+                    color={active ? '#05080F' : colors.aqua}
+                  />
+                  <Text
+                    style={[typography.caption, styles.chipLabel, active && styles.chipLabelActive]}
+                    numberOfLines={1}
+                  >
+                    {sport}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </GlassCard>
+
+        <GlassCard>
+          <View style={styles.sectionHeader}>
+            <Text style={[typography.headingM, styles.sectionTitle]}>Preis & Zeitraum</Text>
+            <Text style={[typography.caption, styles.sectionDescription]}>
+              Definiere Budget und optional einen Wochentag.
+            </Text>
+          </View>
+          <View style={styles.priceRow}>
+            <View style={styles.priceColumn}>
+              <Text style={[typography.caption, styles.caption]}>Min</Text>
+              <TextInput
+                style={[typography.caption, styles.priceInput]}
+                keyboardType="number-pad"
+                placeholder="€"
+                placeholderTextColor="rgba(255,255,255,0.45)"
+                value={filters.priceMin ? String(filters.priceMin) : ''}
+                onChangeText={(value) => handlePriceChange(value, 'priceMin')}
+              />
+            </View>
+            <View style={styles.priceColumn}>
+              <Text style={[typography.caption, styles.caption]}>Max</Text>
+              <TextInput
+                style={[typography.caption, styles.priceInput]}
+                keyboardType="number-pad"
+                placeholder="€"
+                placeholderTextColor="rgba(255,255,255,0.45)"
+                value={filters.priceMax ? String(filters.priceMax) : ''}
+                onChangeText={(value) => handlePriceChange(value, 'priceMax')}
+              />
+            </View>
+          </View>
+          <View style={styles.dayRow}>
+            {weekdayOrder.map((day) => {
+              const active = filters.day === day;
+              return (
+                <TouchableOpacity
+                  key={day}
+                  style={[styles.dayChip, active && styles.dayChipActive]}
+                  onPress={() => updateFilters({ day: active ? '' : day })}
+                >
+                  <Text
+                    style={[typography.caption, styles.dayLabel, active && styles.dayLabelActive]}
+                  >
+                    {weekdayLabels[day].slice(0, 2)}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </GlassCard>
+
+        <GlassCard>
+          <View style={styles.sectionHeader}>
+            <Text style={[typography.headingM, styles.sectionTitle]}>Ausstattung</Text>
+            <Text style={[typography.caption, styles.sectionDescription]}>
+              Markiere relevante Extras für dein Team.
+            </Text>
+          </View>
+          <View style={styles.chipGrid}>
+            {amenityOptions.map((amenity) => {
+              const active = filters.amenities.includes(amenity);
+              return (
+                <TouchableOpacity
+                  key={amenity}
+                  style={[styles.chip, active && styles.chipActive]}
+                  onPress={() => handleAmenityToggle(amenity)}
+                  accessibilityRole="button"
+                >
+                  <Ionicons
+                    name={active ? 'star' : 'star-outline'}
+                    size={16}
+                    color={active ? '#05080F' : colors.aqua}
+                  />
+                  <Text
+                    style={[typography.caption, styles.chipLabel, active && styles.chipLabelActive]}
+                    numberOfLines={1}
+                  >
+                    {amenity}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </GlassCard>
+
+        <View style={styles.summaryCard}>
+          <Text style={[typography.headingM, styles.summaryTitle]}>
+            {filteredVenues.length} {filteredVenues.length === 1 ? 'Treffer' : 'Treffer'}
+          </Text>
+          <Text style={[typography.caption, styles.summaryCaption]}>
+            Ergebnisse werden automatisch für Karte und Listenansicht übernommen.
+          </Text>
+        </View>
+
+        {filteredVenues.map((venue) => (
+          <VenueCard
+            key={venue.id}
+            venue={venue}
+            onPress={() => {
+              navigation.navigate('VenueDetail', { venueId: venue.id });
+            }}
+          />
+        ))}
+
+        {filteredVenues.length === 0 && (
+          <GlassCard contentStyle={styles.emptyContent}>
+            <Ionicons name="sparkles-outline" size={28} color={colors.aqua} />
+            <Text style={[typography.headingM, styles.emptyTitle]}>Keine Treffer</Text>
+            <Text style={[typography.caption, styles.emptyCopy]}>
+              Passe die Filter an oder lösche sie, um weitere Standorte einzublenden.
+            </Text>
+          </GlassCard>
+        )}
       </ScrollView>
     </SafeAreaView>
   );
@@ -28,17 +243,151 @@ const styles = StyleSheet.create({
     backgroundColor: '#05080F'
   },
   container: {
-    padding: 20
+    padding: 20,
+    paddingBottom: 40,
+    gap: 20
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  caption: {
+    color: 'rgba(255,255,255,0.65)'
   },
   title: {
     color: 'white',
-    marginBottom: 20
+    marginTop: 4
   },
-  cardContent: {
-    padding: 20
+  resetButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.35)',
+    backgroundColor: 'rgba(9,14,24,0.55)'
   },
-  copy: {
-    color: 'rgba(255,255,255,0.75)',
-    lineHeight: 22
+  resetLabel: {
+    color: 'white',
+    marginLeft: 6
+  },
+  sectionHeader: {
+    marginBottom: 14
+  },
+  sectionTitle: {
+    color: 'white'
+  },
+  sectionDescription: {
+    color: 'rgba(255,255,255,0.7)',
+    marginTop: 6
+  },
+  inputWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: 'rgba(9,14,24,0.6)',
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.25)',
+    gap: 10
+  },
+  input: {
+    flex: 1,
+    color: 'white'
+  },
+  chipGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 18,
+    backgroundColor: 'rgba(9,14,24,0.6)',
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.2)'
+  },
+  chipActive: {
+    backgroundColor: 'rgba(92,225,230,0.85)'
+  },
+  chipLabel: {
+    color: 'white',
+    marginLeft: 8,
+    maxWidth: 120
+  },
+  chipLabelActive: {
+    color: '#05080F'
+  },
+  priceRow: {
+    flexDirection: 'row',
+    gap: 16,
+    marginBottom: 16
+  },
+  priceColumn: {
+    flex: 1
+  },
+  priceInput: {
+    marginTop: 6,
+    backgroundColor: 'rgba(9,14,24,0.6)',
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.25)',
+    color: 'white'
+  },
+  dayRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10
+  },
+  dayChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.25)',
+    backgroundColor: 'rgba(9,14,24,0.6)'
+  },
+  dayChipActive: {
+    backgroundColor: 'rgba(63,111,219,0.9)',
+    borderColor: 'rgba(63,111,219,0.9)'
+  },
+  dayLabel: {
+    color: 'white'
+  },
+  dayLabelActive: {
+    color: '#05080F'
+  },
+  summaryCard: {
+    padding: 18,
+    borderRadius: 22,
+    backgroundColor: 'rgba(9,14,24,0.7)',
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.25)'
+  },
+  summaryTitle: {
+    color: 'white'
+  },
+  summaryCaption: {
+    color: 'rgba(255,255,255,0.7)',
+    marginTop: 6
+  },
+  emptyContent: {
+    alignItems: 'center',
+    gap: 12
+  },
+  emptyTitle: {
+    color: 'white'
+  },
+  emptyCopy: {
+    color: 'rgba(255,255,255,0.7)',
+    textAlign: 'center'
   }
 });

--- a/ios/src/screens/HomeScreen.tsx
+++ b/ios/src/screens/HomeScreen.tsx
@@ -18,6 +18,8 @@ import { VenueCard } from '../components/VenueCard';
 import { Venue, venues } from '../data/venues';
 import { RootStackParamList, TabParamList } from '../types/navigation';
 import { useTheme } from '../theme/ThemeProvider';
+import { useFilters } from '../context/FiltersContext';
+import { filterVenues } from '../utils/filtering';
 
 type HomeScreenNavigationProp = CompositeNavigationProp<
   BottomTabNavigationProp<TabParamList, 'Home'>,
@@ -66,20 +68,23 @@ const quickFilters: FilterConfig[] = [
 
 export const HomeScreen = ({ navigation }: Props) => {
   const { typography, colors } = useTheme();
+  const { filters } = useFilters();
   const [activeFilters, setActiveFilters] = useState<Set<FilterKey>>(new Set());
+
+  const advancedFiltered = useMemo(() => filterVenues(venues, filters), [filters]);
 
   const filteredVenues = useMemo(() => {
     if (activeFilters.size === 0) {
-      return venues;
+      return advancedFiltered;
     }
 
-    return venues.filter((venue) =>
+    return advancedFiltered.filter((venue) =>
       Array.from(activeFilters).every((key) => {
         const filter = quickFilters.find((item) => item.key === key);
         return filter ? filter.predicate(venue) : true;
       })
     );
-  }, [activeFilters]);
+  }, [activeFilters, advancedFiltered]);
 
   const toggleFilter = (key: FilterKey) => {
     setActiveFilters((prev) => {

--- a/ios/src/screens/MapScreen.tsx
+++ b/ios/src/screens/MapScreen.tsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import MapView, { Marker, PROVIDER_GOOGLE, type LatLng, type Region } from 'react-native-maps';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../theme/ThemeProvider';
+import { GlassCard } from '../components/GlassCard';
+import { Venue, venues } from '../data/venues';
+import { CITY_COORDINATES, DEFAULT_REGION } from '../data/cityCoordinates';
+import { useFilters } from '../context/FiltersContext';
+import { filterVenues, formatCurrency } from '../utils/filtering';
+import { RootStackParamList, TabParamList } from '../types/navigation';
+import { CompositeNavigationProp } from '@react-navigation/native';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+interface MapVenue {
+  venue: Venue;
+  coordinate: LatLng;
+  isLive: boolean;
+}
+
+type MapScreenNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<TabParamList, 'Map'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
+
+interface Props {
+  navigation: MapScreenNavigationProp;
+}
+
+const createDeterministicOffset = (seed: string) => {
+  let hash = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash << 5) - hash + seed.charCodeAt(index);
+    hash |= 0;
+  }
+
+  const lat = ((hash % 1000) / 1000 - 0.5) * 0.08;
+  const lng = ((((hash / 1000) | 0) % 1000) / 1000 - 0.5) * 0.12;
+  return { lat, lng };
+};
+
+const computeMapVenues = (items: Venue[]): MapVenue[] =>
+  items
+    .map((venue, index) => {
+      if (!venue.city) {
+        return null;
+      }
+      const coordinate = CITY_COORDINATES[venue.city] ?? CITY_COORDINATES[venue.city.trim()];
+      if (!coordinate) {
+        return null;
+      }
+      const jitter = createDeterministicOffset(venue.id ?? `venue-${index}`);
+      return {
+        venue,
+        coordinate: {
+          latitude: coordinate.lat + jitter.lat,
+          longitude: coordinate.lng + jitter.lng
+        },
+        isLive: typeof venue.pricePerHour === 'number'
+      } as MapVenue;
+    })
+    .filter((entry): entry is MapVenue => entry !== null);
+
+const computeRegion = (points: MapVenue[]): Region => {
+  if (points.length === 0) {
+    return DEFAULT_REGION;
+  }
+
+  let minLat = Number.POSITIVE_INFINITY;
+  let maxLat = Number.NEGATIVE_INFINITY;
+  let minLng = Number.POSITIVE_INFINITY;
+  let maxLng = Number.NEGATIVE_INFINITY;
+
+  points.forEach(({ coordinate }) => {
+    minLat = Math.min(minLat, coordinate.latitude);
+    maxLat = Math.max(maxLat, coordinate.latitude);
+    minLng = Math.min(minLng, coordinate.longitude);
+    maxLng = Math.max(maxLng, coordinate.longitude);
+  });
+
+  const latitude = (minLat + maxLat) / 2;
+  const longitude = (minLng + maxLng) / 2;
+  const latitudeDelta = Math.max(0.5, (maxLat - minLat) * 1.8);
+  const longitudeDelta = Math.max(0.5, (maxLng - minLng) * 1.8);
+
+  return {
+    latitude,
+    longitude,
+    latitudeDelta,
+    longitudeDelta
+  };
+};
+
+export const MapScreen = ({ navigation }: Props) => {
+  const { typography, colors } = useTheme();
+  const { filters } = useFilters();
+
+  const filteredVenues = useMemo(() => filterVenues(venues, filters), [filters]);
+  const mapVenues = useMemo(() => computeMapVenues(filteredVenues), [filteredVenues]);
+  const initialRegion = useMemo(() => computeRegion(mapVenues), [mapVenues]);
+  const [selectedVenueId, setSelectedVenueId] = useState<string | null>(mapVenues[0]?.venue.id ?? null);
+
+  const selectedVenue = useMemo(
+    () => mapVenues.find((entry) => entry.venue.id === selectedVenueId) ?? null,
+    [mapVenues, selectedVenueId]
+  );
+
+  useEffect(() => {
+    if (mapVenues.length === 0) {
+      setSelectedVenueId(null);
+      return;
+    }
+
+    if (!selectedVenueId || !mapVenues.some((entry) => entry.venue.id === selectedVenueId)) {
+      setSelectedVenueId(mapVenues[0]?.venue.id ?? null);
+    }
+  }, [mapVenues, selectedVenueId]);
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
+      <View style={styles.header}>
+        <View>
+          <Text style={[typography.headingL, styles.title]}>Standorte</Text>
+          <Text style={[typography.caption, styles.subtitle]}>
+            {mapVenues.length} {mapVenues.length === 1 ? 'Halle' : 'Hallen'} auf der Karte
+          </Text>
+        </View>
+        <TouchableOpacity
+          style={styles.filtersButton}
+          onPress={() => navigation.navigate('Filters')}
+          accessibilityRole="button"
+        >
+          <Ionicons name="options-outline" size={18} color={colors.aqua} />
+          <Text style={[typography.caption, styles.filtersLabel]}>Filter anpassen</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.mapWrapper}>
+        <MapView style={StyleSheet.absoluteFill} provider={PROVIDER_GOOGLE} initialRegion={initialRegion}>
+          {mapVenues.map((entry) => (
+            <Marker
+              key={entry.venue.id}
+              coordinate={entry.coordinate}
+              pinColor={entry.isLive ? '#1FB864' : '#9AB8AF'}
+              onPress={() => setSelectedVenueId(entry.venue.id)}
+            />
+          ))}
+        </MapView>
+      </View>
+
+      <GlassCard style={styles.detailsCard} contentStyle={styles.cardContent}>
+        {selectedVenue ? (
+          <View style={styles.cardInner}>
+            <View style={styles.cardHeader}>
+              <View>
+                <Text style={[typography.caption, styles.cardEyebrow]}>{selectedVenue.venue.city}</Text>
+                <Text style={[typography.headingM, styles.cardTitle]} numberOfLines={2}>
+                  {selectedVenue.venue.name}
+                </Text>
+              </View>
+              <View style={styles.pricePill}>
+                <Ionicons name="cash-outline" size={16} color={colors.aqua} />
+                <Text style={[typography.caption, styles.priceLabel]}>
+                  {typeof selectedVenue.venue.pricePerHour === 'number'
+                    ? formatCurrency(selectedVenue.venue.pricePerHour)
+                    : 'Auf Anfrage'}
+                </Text>
+              </View>
+            </View>
+            <Text style={[typography.caption, styles.cardAddress]} numberOfLines={2}>
+              {selectedVenue.venue.address ?? 'Adresse auf Anfrage'}
+            </Text>
+            <View style={styles.cardActions}>
+              <TouchableOpacity
+                style={[styles.actionButton, styles.primaryAction]}
+                onPress={() => navigation.navigate('VenueDetail', { venueId: selectedVenue.venue.id })}
+              >
+                <Text style={[typography.caption, styles.primaryLabel]}>Details öffnen</Text>
+                <Ionicons name="arrow-forward" size={16} color="#05080F" />
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.actionButton, styles.secondaryAction]}
+                onPress={() => setSelectedVenueId(mapVenues[0]?.venue.id ?? null)}
+                disabled={mapVenues.length === 0}
+              >
+                <Ionicons name="locate" size={16} color={colors.aqua} />
+                <Text style={[typography.caption, styles.secondaryLabel]}>Ersten Standort fokussieren</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.emptyState}>
+            <Ionicons name="map-outline" size={28} color={colors.aqua} />
+            <Text style={[typography.headingM, styles.emptyTitle]}>Keine Marker verfügbar</Text>
+            <Text style={[typography.caption, styles.emptyCopy]}>
+              Aktiviere weitere Filter oder entferne Eingrenzungen, um Standorte einzublenden.
+            </Text>
+          </View>
+        )}
+      </GlassCard>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#05080F'
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 16
+  },
+  title: {
+    color: 'white'
+  },
+  subtitle: {
+    color: 'rgba(255,255,255,0.7)',
+    marginTop: 4
+  },
+  filtersButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.35)',
+    backgroundColor: 'rgba(9,14,24,0.6)'
+  },
+  filtersLabel: {
+    color: 'white',
+    marginLeft: 6
+  },
+  mapWrapper: {
+    flex: 1,
+    marginHorizontal: 20,
+    borderRadius: 28,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.2)'
+  },
+  detailsCard: {
+    marginHorizontal: 20,
+    marginTop: -36,
+    marginBottom: 20
+  },
+  cardContent: {
+    padding: 20
+  },
+  cardInner: {
+    gap: 16
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 16
+  },
+  cardEyebrow: {
+    color: 'rgba(255,255,255,0.6)',
+    letterSpacing: 1.2
+  },
+  cardTitle: {
+    color: 'white',
+    marginTop: 6
+  },
+  pricePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: 'rgba(92,225,230,0.14)'
+  },
+  priceLabel: {
+    color: 'white',
+    marginLeft: 6
+  },
+  cardAddress: {
+    color: 'rgba(255,255,255,0.75)'
+  },
+  cardActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 16
+  },
+  primaryAction: {
+    backgroundColor: 'rgba(63,111,219,0.9)'
+  },
+  primaryLabel: {
+    color: '#05080F',
+    marginRight: 8
+  },
+  secondaryAction: {
+    borderWidth: 1,
+    borderColor: 'rgba(92,225,230,0.35)',
+    backgroundColor: 'rgba(9,14,24,0.5)'
+  },
+  secondaryLabel: {
+    color: 'white',
+    marginLeft: 6
+  },
+  emptyState: {
+    alignItems: 'center',
+    gap: 12
+  },
+  emptyTitle: {
+    color: 'white'
+  },
+  emptyCopy: {
+    color: 'rgba(255,255,255,0.7)',
+    textAlign: 'center'
+  }
+});

--- a/ios/src/types/navigation.ts
+++ b/ios/src/types/navigation.ts
@@ -1,11 +1,12 @@
 export type TabParamList = {
   Home: undefined;
   Favorites: undefined;
-  Filters: undefined;
+  Map: undefined;
   Profile: undefined;
 };
 
 export type RootStackParamList = {
   Tabs: undefined;
+  Filters: undefined;
   VenueDetail: { venueId: string } | undefined;
 };

--- a/ios/src/utils/filtering.ts
+++ b/ios/src/utils/filtering.ts
@@ -1,0 +1,66 @@
+import type { Venue } from '../data/venues';
+import type { FilterState, Weekday } from '../context/FiltersContext';
+
+export const weekdayOrder: Weekday[] = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday'
+];
+
+export const filterVenues = (items: Venue[], filters: FilterState): Venue[] => {
+  const normalizedCity = filters.city.trim().toLowerCase();
+
+  return items.filter((venue) => {
+    if (filters.sports.length > 0 && !filters.sports.every((sport) => venue.sports.includes(sport))) {
+      return false;
+    }
+
+    if (normalizedCity.length > 0) {
+      const haystack = `${venue.city ?? ''} ${venue.address ?? ''}`.toLowerCase();
+      if (!haystack.includes(normalizedCity)) {
+        return false;
+      }
+    }
+
+    if (
+      typeof filters.priceMin === 'number' &&
+      (typeof venue.pricePerHour !== 'number' || venue.pricePerHour < filters.priceMin)
+    ) {
+      return false;
+    }
+
+    if (
+      typeof filters.priceMax === 'number' &&
+      (typeof venue.pricePerHour !== 'number' || venue.pricePerHour > filters.priceMax)
+    ) {
+      return false;
+    }
+
+    if (filters.day) {
+      const schedule = venue.openingHours?.[filters.day];
+      if (!schedule || (schedule.open === '' && schedule.close === '')) {
+        return false;
+      }
+    }
+
+    if (filters.amenities.length > 0) {
+      const amenities = venue.amenities ?? [];
+      if (!filters.amenities.every((amenity) => amenities.includes(amenity))) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+};
+
+export const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0
+  }).format(value);


### PR DESCRIPTION
## Summary
- replace the old Filters tab with a dedicated Map tab that renders markers for all venues using react-native-maps
- add a shared filter context and rebuild the Filters screen with location, sport, price, day, and amenity controls that update results in real time
- apply the shared filters to the home list and map views and register the necessary coordinate data and dependency

## Testing
- npm run lint *(fails: Invalid option '--ext' with current ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e121d641388332880f09ae4400176e